### PR TITLE
Change command prefix format to " /prefix "

### DIFF
--- a/src/main/java/networkbook/logic/commands/AddCommand.java
+++ b/src/main/java/networkbook/logic/commands/AddCommand.java
@@ -18,18 +18,18 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the network book. "
             + "Parameters: "
-            + CliSyntax.PREFIX_NAME + "NAME "
-            + CliSyntax.PREFIX_PHONE + "PHONE "
-            + CliSyntax.PREFIX_EMAIL + "EMAIL "
-            + CliSyntax.PREFIX_ADDRESS + "ADDRESS "
-            + "[" + CliSyntax.PREFIX_TAG + "TAG]...\n"
+            + CliSyntax.PREFIX_NAME + " NAME "
+            + CliSyntax.PREFIX_PHONE + " PHONE "
+            + CliSyntax.PREFIX_EMAIL + " EMAIL "
+            + CliSyntax.PREFIX_ADDRESS + " ADDRESS "
+            + "[" + CliSyntax.PREFIX_TAG + " TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + CliSyntax.PREFIX_NAME + "John Doe "
-            + CliSyntax.PREFIX_PHONE + "98765432 "
-            + CliSyntax.PREFIX_EMAIL + "johnd@example.com "
-            + CliSyntax.PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + CliSyntax.PREFIX_TAG + "friends "
-            + CliSyntax.PREFIX_TAG + "owesMoney";
+            + CliSyntax.PREFIX_NAME + " John Doe "
+            + CliSyntax.PREFIX_PHONE + " 98765432 "
+            + CliSyntax.PREFIX_EMAIL + " johnd@example.com "
+            + CliSyntax.PREFIX_ADDRESS + " 311, Clementi Ave 2, #02-25 "
+            + CliSyntax.PREFIX_TAG + " friends "
+            + CliSyntax.PREFIX_TAG + " owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the network book";

--- a/src/main/java/networkbook/logic/commands/EditCommand.java
+++ b/src/main/java/networkbook/logic/commands/EditCommand.java
@@ -36,14 +36,14 @@ public class EditCommand extends Command {
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + CliSyntax.PREFIX_NAME + "NAME] "
-            + "[" + CliSyntax.PREFIX_PHONE + "PHONE] "
-            + "[" + CliSyntax.PREFIX_EMAIL + "EMAIL] "
-            + "[" + CliSyntax.PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + CliSyntax.PREFIX_TAG + "TAG]...\n"
+            + "[" + CliSyntax.PREFIX_NAME + " NAME] "
+            + "[" + CliSyntax.PREFIX_PHONE + " PHONE] "
+            + "[" + CliSyntax.PREFIX_EMAIL + " EMAIL] "
+            + "[" + CliSyntax.PREFIX_ADDRESS + " ADDRESS] "
+            + "[" + CliSyntax.PREFIX_TAG + " TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + CliSyntax.PREFIX_PHONE + "91234567 "
-            + CliSyntax.PREFIX_EMAIL + "johndoe@example.com";
+            + CliSyntax.PREFIX_PHONE + " 91234567 "
+            + CliSyntax.PREFIX_EMAIL + " johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/networkbook/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/networkbook/logic/parser/ArgumentTokenizer.java
@@ -119,8 +119,8 @@ public class ArgumentTokenizer {
                                         PrefixPosition nextPrefixPosition) {
         Prefix prefix = currentPrefixPosition.getPrefix();
 
-        int valueStartPos = currentPrefixPosition.getStartPosition() +
-                                prefix.getPrefix().length() + 1; // +1  as offset for whitespace
+        int valueStartPos = currentPrefixPosition.getStartPosition()
+                                + prefix.getPrefix().length() + 1; // +1  as offset for whitespace
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
         return value.trim();

--- a/src/main/java/networkbook/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/networkbook/logic/parser/ArgumentTokenizer.java
@@ -7,10 +7,10 @@ import java.util.stream.Collectors;
 
 /**
  * Tokenizes arguments string of the form: {@code preamble <prefix>value <prefix>value ...}<br>
- *     e.g. {@code some preamble text t/ 11.00 t/12.00 k/ m/ July}  where prefixes are {@code t/ k/ m/}.<br>
- * 1. An argument's value can be an empty string e.g. the value of {@code k/} in the above example.<br>
+ *     e.g. {@code some preamble text /tag a /name /tag b /index 1}  where prefixes are {@code /tag /name /index}.<br>
+ * 1. An argument's value can be an empty string e.g. the value of {@code /name} in the above example.<br>
  * 2. Leading and trailing whitespaces of an argument value will be discarded.<br>
- * 3. An argument may be repeated and all its values will be accumulated e.g. the value of {@code t/}
+ * 3. An argument may be repeated and all its values will be accumulated e.g. the value of {@code /tag}
  *    in the above example.<br>
  */
 public class ArgumentTokenizer {
@@ -24,14 +24,15 @@ public class ArgumentTokenizer {
      * @return           ArgumentMultimap object that maps prefixes to their arguments
      */
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
-        List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
-        return extractArguments(argsString, positions);
+        String argsStringWithPadding = argsString + " "; // to prevent last word being a prefix
+        List<PrefixPosition> positions = findAllPrefixPositions(argsStringWithPadding, prefixes);
+        return extractArguments(argsStringWithPadding, positions);
     }
 
     /**
      * Finds all zero-based prefix positions in the given arguments string.
      *
-     * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
+     * @param argsString Arguments string of the form: {@code preamble <prefix> value <prefix> value ...}
      * @param prefixes   Prefixes to find in the arguments string
      * @return           List of zero-based prefix positions in the given arguments string
      */
@@ -60,17 +61,17 @@ public class ArgumentTokenizer {
     /**
      * Returns the index of the first occurrence of {@code prefix} in
      * {@code argsString} starting from index {@code fromIndex}. An occurrence
-     * is valid if there is a whitespace before {@code prefix}. Returns -1 if no
-     * such occurrence can be found.
+     * is valid if there is a whitespace before and after {@code prefix}.
+     * Returns -1 if no such occurrence can be found.
      *
-     * E.g if {@code argsString} = "e/hip/900", {@code prefix} = "p/" and
+     * E.g if {@code argsString} = "/tag friend /index1", {@code prefix} = "/index" and
      * {@code fromIndex} = 0, this method returns -1 as there are no valid
-     * occurrences of "p/" with whitespace before it. However, if
-     * {@code argsString} = "e/hi p/900", {@code prefix} = "p/" and
-     * {@code fromIndex} = 0, this method returns 5.
+     * occurrences of "/index" with whitespace before and after it. However, if
+     * {@code argsString} = "/tag friend /index 1", {@code prefix} = "/index" and
+     * {@code fromIndex} = 0, this method returns 12.
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
+        int prefixIndex = argsString.indexOf(" " + prefix + " ", fromIndex);
         return prefixIndex == -1 ? -1
                 : prefixIndex + 1; // +1 as offset for whitespace
     }
@@ -80,7 +81,7 @@ public class ArgumentTokenizer {
      * extracted prefixes to their respective arguments. Prefixes are extracted based on their zero-based positions in
      * {@code argsString}.
      *
-     * @param argsString      Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
+     * @param argsString      Arguments string of the form: {@code preamble <prefix> value <prefix> value ...}
      * @param prefixPositions Zero-based positions of all prefixes in {@code argsString}
      * @return                ArgumentMultimap object that maps prefixes to their arguments
      */
@@ -90,7 +91,7 @@ public class ArgumentTokenizer {
         prefixPositions.sort((prefix1, prefix2) -> prefix1.getStartPosition() - prefix2.getStartPosition());
 
         // Insert a PrefixPosition to represent the preamble
-        PrefixPosition preambleMarker = new PrefixPosition(new Prefix(""), 0);
+        PrefixPosition preambleMarker = new PrefixPosition(new Prefix(""), -1);
         prefixPositions.add(0, preambleMarker);
 
         // Add a dummy PrefixPosition to represent the end of the string
@@ -118,7 +119,8 @@ public class ArgumentTokenizer {
                                         PrefixPosition nextPrefixPosition) {
         Prefix prefix = currentPrefixPosition.getPrefix();
 
-        int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
+        int valueStartPos = currentPrefixPosition.getStartPosition() +
+                                prefix.getPrefix().length() + 1; // +1  as offset for whitespace
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
         return value.trim();

--- a/src/main/java/networkbook/logic/parser/CliSyntax.java
+++ b/src/main/java/networkbook/logic/parser/CliSyntax.java
@@ -6,10 +6,10 @@ package networkbook.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_NAME = new Prefix("/name");
+    public static final Prefix PREFIX_PHONE = new Prefix("/phone");
+    public static final Prefix PREFIX_EMAIL = new Prefix("/email");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("/address");
+    public static final Prefix PREFIX_TAG = new Prefix("/tag");
 
 }

--- a/src/test/java/networkbook/logic/commands/CommandTestUtil.java
+++ b/src/test/java/networkbook/logic/commands/CommandTestUtil.java
@@ -44,12 +44,16 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + CliSyntax.PREFIX_TAG + " " + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + CliSyntax.PREFIX_TAG + " " + VALID_TAG_HUSBAND;
 
-    public static final String INVALID_NAME_DESC = " " + CliSyntax.PREFIX_NAME + " " + "James&"; // '&' not allowed in names
-    public static final String INVALID_PHONE_DESC = " " + CliSyntax.PREFIX_PHONE + " " + "911a"; // 'a' not allowed in phones
-    public static final String INVALID_EMAIL_DESC = " " + CliSyntax.PREFIX_EMAIL + " " + "bob!yahoo"; // missing '@' symbol
+    public static final String INVALID_NAME_DESC = " " + CliSyntax.PREFIX_NAME
+                                                        + " " + "James&"; // '&' not allowed in names
+    public static final String INVALID_PHONE_DESC = " " + CliSyntax.PREFIX_PHONE
+                                                        + " " + "911a"; // 'a' not allowed in phones
+    public static final String INVALID_EMAIL_DESC = " " + CliSyntax.PREFIX_EMAIL
+                                                        + " " + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC =
             " " + CliSyntax.PREFIX_ADDRESS; // empty string not allowed for addresses
-    public static final String INVALID_TAG_DESC = " " + CliSyntax.PREFIX_TAG + " " + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_TAG_DESC = " " + CliSyntax.PREFIX_TAG
+                                                        + " " + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/networkbook/logic/commands/CommandTestUtil.java
+++ b/src/test/java/networkbook/logic/commands/CommandTestUtil.java
@@ -33,23 +33,23 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
-    public static final String NAME_DESC_AMY = " " + CliSyntax.PREFIX_NAME + VALID_NAME_AMY;
-    public static final String NAME_DESC_BOB = " " + CliSyntax.PREFIX_NAME + VALID_NAME_BOB;
-    public static final String PHONE_DESC_AMY = " " + CliSyntax.PREFIX_PHONE + VALID_PHONE_AMY;
-    public static final String PHONE_DESC_BOB = " " + CliSyntax.PREFIX_PHONE + VALID_PHONE_BOB;
-    public static final String EMAIL_DESC_AMY = " " + CliSyntax.PREFIX_EMAIL + VALID_EMAIL_AMY;
-    public static final String EMAIL_DESC_BOB = " " + CliSyntax.PREFIX_EMAIL + VALID_EMAIL_BOB;
-    public static final String ADDRESS_DESC_AMY = " " + CliSyntax.PREFIX_ADDRESS + VALID_ADDRESS_AMY;
-    public static final String ADDRESS_DESC_BOB = " " + CliSyntax.PREFIX_ADDRESS + VALID_ADDRESS_BOB;
-    public static final String TAG_DESC_FRIEND = " " + CliSyntax.PREFIX_TAG + VALID_TAG_FRIEND;
-    public static final String TAG_DESC_HUSBAND = " " + CliSyntax.PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String NAME_DESC_AMY = " " + CliSyntax.PREFIX_NAME + " " + VALID_NAME_AMY;
+    public static final String NAME_DESC_BOB = " " + CliSyntax.PREFIX_NAME + " " + VALID_NAME_BOB;
+    public static final String PHONE_DESC_AMY = " " + CliSyntax.PREFIX_PHONE + " " + VALID_PHONE_AMY;
+    public static final String PHONE_DESC_BOB = " " + CliSyntax.PREFIX_PHONE + " " + VALID_PHONE_BOB;
+    public static final String EMAIL_DESC_AMY = " " + CliSyntax.PREFIX_EMAIL + " " + VALID_EMAIL_AMY;
+    public static final String EMAIL_DESC_BOB = " " + CliSyntax.PREFIX_EMAIL + " " + VALID_EMAIL_BOB;
+    public static final String ADDRESS_DESC_AMY = " " + CliSyntax.PREFIX_ADDRESS + " " + VALID_ADDRESS_AMY;
+    public static final String ADDRESS_DESC_BOB = " " + CliSyntax.PREFIX_ADDRESS + " " + VALID_ADDRESS_BOB;
+    public static final String TAG_DESC_FRIEND = " " + CliSyntax.PREFIX_TAG + " " + VALID_TAG_FRIEND;
+    public static final String TAG_DESC_HUSBAND = " " + CliSyntax.PREFIX_TAG + " " + VALID_TAG_HUSBAND;
 
-    public static final String INVALID_NAME_DESC = " " + CliSyntax.PREFIX_NAME + "James&"; // '&' not allowed in names
-    public static final String INVALID_PHONE_DESC = " " + CliSyntax.PREFIX_PHONE + "911a"; // 'a' not allowed in phones
-    public static final String INVALID_EMAIL_DESC = " " + CliSyntax.PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
+    public static final String INVALID_NAME_DESC = " " + CliSyntax.PREFIX_NAME + " " + "James&"; // '&' not allowed in names
+    public static final String INVALID_PHONE_DESC = " " + CliSyntax.PREFIX_PHONE + " " + "911a"; // 'a' not allowed in phones
+    public static final String INVALID_EMAIL_DESC = " " + CliSyntax.PREFIX_EMAIL + " " + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC =
             " " + CliSyntax.PREFIX_ADDRESS; // empty string not allowed for addresses
-    public static final String INVALID_TAG_DESC = " " + CliSyntax.PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_TAG_DESC = " " + CliSyntax.PREFIX_TAG + " " + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/networkbook/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/AddCommandParserTest.java
@@ -73,9 +73,9 @@ public class AddCommandParserTest {
                         + CommandTestUtil.ADDRESS_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(
                         CliSyntax.PREFIX_NAME,
-                        CliSyntax.PREFIX_ADDRESS,
+                        CliSyntax.PREFIX_PHONE,
                         CliSyntax.PREFIX_EMAIL,
-                        CliSyntax.PREFIX_PHONE));
+                        CliSyntax.PREFIX_ADDRESS));
 
         // invalid value followed by valid value
 

--- a/src/test/java/networkbook/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/networkbook/logic/parser/ArgumentTokenizerTest.java
@@ -82,7 +82,7 @@ public class ArgumentTokenizerTest {
     @Test
     public void tokenize_multipleArguments() {
         // Only two arguments are present
-        String argsString = "SomePreambleString -t dashT-Value p/pSlash value";
+        String argsString = "SomePreambleString -t dashT-Value p/ pSlash value";
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
         assertPreamblePresent(argMultimap, "SomePreambleString");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
@@ -90,7 +90,7 @@ public class ArgumentTokenizerTest {
         assertArgumentAbsent(argMultimap, hatQ);
 
         // All three arguments are present
-        argsString = "Different Preamble String ^Q111 -t dashT-Value p/pSlash value";
+        argsString = "Different Preamble String ^Q 111 -t dashT-Value p/ pSlash value";
         argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
         assertPreamblePresent(argMultimap, "Different Preamble String");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");

--- a/src/test/java/networkbook/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/EditCommandParserTest.java
@@ -19,7 +19,7 @@ import networkbook.testutil.TypicalIndexes;
 
 public class EditCommandParserTest {
 
-    private static final String TAG_EMPTY = " " + CliSyntax.PREFIX_TAG;
+    private static final String TAG_EMPTY = " " + CliSyntax.PREFIX_TAG + " ";
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);

--- a/src/test/java/networkbook/testutil/PersonUtil.java
+++ b/src/test/java/networkbook/testutil/PersonUtil.java
@@ -27,14 +27,14 @@ public class PersonUtil {
      */
     public static String getPersonDetails(Person person) {
         StringBuilder sb = new StringBuilder();
-        sb.append(CliSyntax.PREFIX_NAME + person.getName().fullName + " ");
-        sb.append(CliSyntax.PREFIX_PHONE + person.getPhone().value + " ");
+        sb.append(CliSyntax.PREFIX_NAME + " " + person.getName().fullName + " ");
+        sb.append(CliSyntax.PREFIX_PHONE + " " + person.getPhone().value + " ");
         person.getEmails().stream().forEach(
-                e -> sb.append(CliSyntax.PREFIX_EMAIL + e.toString() + " ")
+                e -> sb.append(CliSyntax.PREFIX_EMAIL + " " + e.toString() + " ")
         );
-        sb.append(CliSyntax.PREFIX_ADDRESS + person.getAddress().value + " ");
+        sb.append(CliSyntax.PREFIX_ADDRESS + " " + person.getAddress().value + " ");
         person.getTags().stream().forEach(
-            s -> sb.append(CliSyntax.PREFIX_TAG + s.tagName + " ")
+            s -> sb.append(CliSyntax.PREFIX_TAG + " " + s.tagName + " ")
         );
         return sb.toString();
     }
@@ -44,24 +44,28 @@ public class PersonUtil {
      */
     public static String getEditPersonDescriptorDetails(EditCommand.EditPersonDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getName().ifPresent(name -> sb.append(CliSyntax.PREFIX_NAME).append(name.fullName).append(" "));
-        descriptor.getPhone().ifPresent(phone -> sb.append(CliSyntax.PREFIX_PHONE).append(phone.value).append(" "));
+        descriptor.getName().ifPresent(name -> sb.append(CliSyntax.PREFIX_NAME).append(" ")
+                                                    .append(name.fullName).append(" "));
+        descriptor.getPhone().ifPresent(phone -> sb.append(CliSyntax.PREFIX_PHONE).append(" ")
+                                                    .append(phone.value).append(" "));
         if (descriptor.getEmails().isPresent()) {
             UniqueList<Email> emails = descriptor.getEmails().get();
             if (emails.isEmpty()) {
-                sb.append(CliSyntax.PREFIX_EMAIL);
+                sb.append(CliSyntax.PREFIX_EMAIL).append(" ");
             } else {
-                emails.forEach(e -> sb.append(CliSyntax.PREFIX_EMAIL).append(e.toString()).append(" "));
+                emails.forEach(e -> sb.append(CliSyntax.PREFIX_EMAIL).append(" ")
+                                                    .append(e.toString()).append(" "));
             }
         }
-        descriptor.getAddress().ifPresent(address -> sb.append(CliSyntax.PREFIX_ADDRESS)
-                .append(address.value).append(" "));
+        descriptor.getAddress().ifPresent(address -> sb.append(CliSyntax.PREFIX_ADDRESS).append(" ")
+                                                    .append(address.value).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
-                sb.append(CliSyntax.PREFIX_TAG);
+                sb.append(CliSyntax.PREFIX_TAG).append(" ");
             } else {
-                tags.forEach(s -> sb.append(CliSyntax.PREFIX_TAG).append(s.tagName).append(" "));
+                tags.forEach(s -> sb.append(CliSyntax.PREFIX_TAG).append(" ")
+                                                    .append(s.tagName).append(" "));
             }
         }
         return sb.toString();


### PR DESCRIPTION
- e.g. " n/jl" becomes " /name jl"
- Add trailing whitespace for patterns in parser & tokenizer
- Update tests, docs and error messages