### PR TITLE
Enable search by fragment of contact name

### DIFF
--- a/src/main/java/networkbook/commons/util/StringUtil.java
+++ b/src/main/java/networkbook/commons/util/StringUtil.java
@@ -29,13 +29,41 @@ public class StringUtil {
 
         String preppedWord = word.trim();
         checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
-        checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
+        checkArgument(preppedWord.split("\\s+").length == 1,
+                "Word parameter should be a single word");
 
         String preppedSentence = sentence;
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
         return Arrays.stream(wordsInPreppedSentence)
                 .anyMatch(preppedWord::equalsIgnoreCase);
+    }
+
+    /**
+     * Returns true if the {@code sentence} contains the {@code term}.
+     *   Ignores case, a full word match is not required.
+     *   <br>examples:<pre>
+     *       containsWordIgnoreCase("ABc def", "ab") == true
+     *       containsWordIgnoreCase("ABc def", "EF") == true
+     *       containsWordIgnoreCase("ABc def", "cd") == false //term not contained in a single word
+     *       </pre>
+     * @param sentence cannot be null
+     * @param term cannot be null, cannot be empty, must be a single term/word
+     */
+    public static boolean containsTermIgnoreCase(String sentence, String term) {
+        requireNonNull(sentence);
+        requireNonNull(term);
+
+        String preppedTerm = term.trim();
+        checkArgument(!preppedTerm.isEmpty(), "Term parameter cannot be empty");
+        checkArgument(preppedTerm.split("\\s+").length == 1,
+                "Term parameter should be a single term");
+
+        String preppedSentence = sentence;
+        String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
+
+        return Arrays.stream(wordsInPreppedSentence)
+                .anyMatch((word) -> word.toLowerCase().contains(preppedTerm.toLowerCase()));
     }
 
     /**

--- a/src/main/java/networkbook/logic/commands/FindCommand.java
+++ b/src/main/java/networkbook/logic/commands/FindCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import networkbook.commons.util.ToStringBuilder;
 import networkbook.logic.Messages;
 import networkbook.model.Model;
-import networkbook.model.person.NameContainsKeywordsPredicate;
+import networkbook.model.person.NameContainsKeyTermsPredicate;
 
 /**
  * Finds and lists all persons in network book whose name contains any of the argument keywords.
@@ -20,9 +20,9 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final NameContainsKeyTermsPredicate predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(NameContainsKeyTermsPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/networkbook/logic/parser/FindCommandParser.java
+++ b/src/main/java/networkbook/logic/parser/FindCommandParser.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import networkbook.logic.Messages;
 import networkbook.logic.commands.FindCommand;
 import networkbook.logic.parser.exceptions.ParseException;
-import networkbook.model.person.NameContainsKeywordsPredicate;
+import networkbook.model.person.NameContainsKeyTermsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -24,9 +24,9 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        String[] nameKeyTerms = trimmedArgs.split("\\s+");
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindCommand(new NameContainsKeyTermsPredicate(Arrays.asList(nameKeyTerms)));
     }
 
 }

--- a/src/main/java/networkbook/model/person/NameContainsKeyTermsPredicate.java
+++ b/src/main/java/networkbook/model/person/NameContainsKeyTermsPredicate.java
@@ -1,0 +1,44 @@
+package networkbook.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import networkbook.commons.util.StringUtil;
+import networkbook.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} matches any of the key terms given.
+ */
+public class NameContainsKeyTermsPredicate implements Predicate<Person> {
+    private final List<String> keyTerms;
+
+    public NameContainsKeyTermsPredicate(List<String> keyTerms) {
+        this.keyTerms = keyTerms;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keyTerms.stream()
+                .anyMatch(keyTerm -> StringUtil.containsTermIgnoreCase(person.getName().fullName, keyTerm));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof NameContainsKeyTermsPredicate)) {
+            return false;
+        }
+
+        NameContainsKeyTermsPredicate otherNameContainsKeyTermsPredicate = (NameContainsKeyTermsPredicate) other;
+        return keyTerms.equals(otherNameContainsKeyTermsPredicate.keyTerms);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("key terms", keyTerms).toString();
+    }
+}

--- a/src/test/java/networkbook/commons/util/StringUtilTest.java
+++ b/src/test/java/networkbook/commons/util/StringUtilTest.java
@@ -56,7 +56,8 @@ public class StringUtilTest {
 
     @Test
     public void containsWordIgnoreCase_nullWord_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsWordIgnoreCase("typical sentence", null));
+        assertThrows(NullPointerException.class, ()
+                -> StringUtil.containsWordIgnoreCase("typical sentence", null));
     }
 
     @Test
@@ -123,6 +124,87 @@ public class StringUtilTest {
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
     }
 
+    //---------------- Tests for containsTermIgnoreCase --------------------------------------
+
+    /*
+     * Invalid equivalence partitions for term: null, empty, multiple terms
+     * Invalid equivalence partitions for sentence: null
+     * The four test cases below test one invalid input at a time.
+     */
+
+    @Test
+    public void containsTermIgnoreCase_nullTerm_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, ()
+                -> StringUtil.containsTermIgnoreCase("typical sentence", null));
+    }
+
+    @Test
+    public void containsTermIgnoreCase_emptyWord_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Term parameter cannot be empty", ()
+                -> StringUtil.containsTermIgnoreCase("typical sentence", "  "));
+    }
+
+    @Test
+    public void containsTermIgnoreCase_multipleTerms_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, "Term parameter should be a single term", ()
+                -> StringUtil.containsTermIgnoreCase("typical sentence", "aaa BBB"));
+    }
+
+    @Test
+    public void containsTermIgnoreCase_nullSentence_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsTermIgnoreCase(null, "abc"));
+    }
+
+    /*
+     * Valid equivalence partitions for term:
+     *   - any term
+     *   - term containing symbols/numbers
+     *   - term with leading/trailing spaces
+     *
+     * Valid equivalence partitions for sentence:
+     *   - empty string
+     *   - one word
+     *   - multiple words
+     *   - sentence with extra spaces
+     *
+     * Possible scenarios returning true:
+     *   - matches any word in sentence
+     *   - matches multiple words
+     *   - query term matches part of a sentence word
+     *
+     * Possible scenarios returning false:
+     *   - sentence word matches part of the query term
+     *
+     * The test method below tries to verify all above with a reasonably low number of test cases.
+     */
+
+    @Test
+    public void containsTermIgnoreCase_validInputs_correctResult() {
+
+        // Empty sentence
+        assertFalse(StringUtil.containsTermIgnoreCase("", "abc")); // Boundary case
+        assertFalse(StringUtil.containsTermIgnoreCase("    ", "123"));
+
+        // Query word bigger than sentence word
+        assertFalse(StringUtil.containsTermIgnoreCase("aaa bbb ccc", "bbbb"));
+
+        // Matches word in the sentence, different upper/lower case letters
+        assertTrue(StringUtil.containsTermIgnoreCase("aaa bBb ccc", "Aaa")); // First word (boundary case)
+        assertTrue(StringUtil.containsTermIgnoreCase("aaa bBb ccc@1", "CCc@1")); // Last word (boundary case)
+        assertTrue(StringUtil.containsTermIgnoreCase("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces
+        assertTrue(StringUtil.containsTermIgnoreCase("Aaa", "aaa")); // Only one word in sentence (boundary case)
+        assertTrue(StringUtil.containsTermIgnoreCase("aaa bbb ccc", "  ccc  ")); // Leading/trailing spaces
+
+        // Matches multiple words in sentence
+        assertTrue(StringUtil.containsTermIgnoreCase("AAA bBb ccc  bbb", "bbB"));
+
+        // Matches word in the sentence, different upper/lower case letters
+        assertTrue(StringUtil.containsTermIgnoreCase("aaa bBb ccc", "Aa")); // First word (boundary case)
+        assertTrue(StringUtil.containsTermIgnoreCase("aaa bBb ccc@1", "cc@1")); // Last word (boundary case)
+        assertTrue(StringUtil.containsTermIgnoreCase("  AAA   bBb   ccc  ", "aa")); // Sentence has extra spaces
+        assertTrue(StringUtil.containsTermIgnoreCase("Aab", "aa")); // Only one word in sentence (boundary case)
+        assertTrue(StringUtil.containsTermIgnoreCase("aaa bbb ccc", "  cc  ")); // Leading/trailing spaces
+    }
     //---------------- Tests for getDetails --------------------------------------
 
     /*

--- a/src/test/java/networkbook/logic/commands/FindCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/FindCommandTest.java
@@ -13,7 +13,7 @@ import networkbook.logic.Messages;
 import networkbook.model.Model;
 import networkbook.model.ModelManager;
 import networkbook.model.UserPrefs;
-import networkbook.model.person.NameContainsKeywordsPredicate;
+import networkbook.model.person.NameContainsKeyTermsPredicate;
 import networkbook.testutil.TypicalPersons;
 
 /**
@@ -25,10 +25,10 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        NameContainsKeyTermsPredicate firstPredicate =
+                new NameContainsKeyTermsPredicate(Collections.singletonList("first"));
+        NameContainsKeyTermsPredicate secondPredicate =
+                new NameContainsKeyTermsPredicate(Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -53,7 +53,27 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        NameContainsKeyTermsPredicate predicate = preparePredicate(" ");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        CommandTestUtil.assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_singleUnmatchedKeyword_noPersonFound() {
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        NameContainsKeyTermsPredicate predicate = preparePredicate("Ulfred");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        CommandTestUtil.assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleUnmatchedKeywords_noPersonFound() {
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        NameContainsKeyTermsPredicate predicate = preparePredicate("Ulfred  Snyder");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         CommandTestUtil.assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -63,7 +83,7 @@ public class FindCommandTest {
     @Test
     public void execute_singleUniqueKeyword_matchingPersonFound() {
         String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Fiona");
+        NameContainsKeyTermsPredicate predicate = preparePredicate("Fiona");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         CommandTestUtil.assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -76,7 +96,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleUniqueKeywords_matchingPersonFound() {
         String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Fiona   Kunz");
+        NameContainsKeyTermsPredicate predicate = preparePredicate("Fiona   Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         CommandTestUtil.assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -87,9 +107,22 @@ public class FindCommandTest {
     }
 
     @Test
+    public void execute_singleSharedKeyword_multiplePersonsFound() {
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        NameContainsKeyTermsPredicate predicate = preparePredicate("Ku");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        CommandTestUtil.assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(
+                Arrays.asList(TypicalPersons.CARL, TypicalPersons.FIONA),
+                model.getFilteredPersonList()
+        );
+    }
+
+    @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        NameContainsKeyTermsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         CommandTestUtil.assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -101,16 +134,16 @@ public class FindCommandTest {
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
+        NameContainsKeyTermsPredicate predicate = new NameContainsKeyTermsPredicate(Arrays.asList("keyword"));
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
     }
 
     /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code NameContainsKeyTermsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private NameContainsKeyTermsPredicate preparePredicate(String userInput) {
+        return new NameContainsKeyTermsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/networkbook/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/FindCommandParserTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import networkbook.logic.Messages;
 import networkbook.logic.commands.FindCommand;
-import networkbook.model.person.NameContainsKeywordsPredicate;
+import networkbook.model.person.NameContainsKeyTermsPredicate;
 
 public class FindCommandParserTest {
 
@@ -25,7 +25,7 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand(new NameContainsKeyTermsPredicate(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/networkbook/logic/parser/NetworkBookParserTest.java
+++ b/src/test/java/networkbook/logic/parser/NetworkBookParserTest.java
@@ -20,7 +20,7 @@ import networkbook.logic.commands.FindCommand;
 import networkbook.logic.commands.HelpCommand;
 import networkbook.logic.commands.ListCommand;
 import networkbook.logic.parser.exceptions.ParseException;
-import networkbook.model.person.NameContainsKeywordsPredicate;
+import networkbook.model.person.NameContainsKeyTermsPredicate;
 import networkbook.model.person.Person;
 import networkbook.testutil.EditPersonDescriptorBuilder;
 import networkbook.testutil.PersonBuilder;
@@ -72,7 +72,7 @@ public class NetworkBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new NameContainsKeyTermsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/networkbook/model/person/NameContainsKeyTermsPredicateTest.java
+++ b/src/test/java/networkbook/model/person/NameContainsKeyTermsPredicateTest.java
@@ -1,0 +1,103 @@
+package networkbook.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import networkbook.testutil.PersonBuilder;
+
+public class NameContainsKeyTermsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeyTermList = Collections.singletonList("first");
+        List<String> secondPredicateKeyTermList = Arrays.asList("first", "second");
+
+        NameContainsKeyTermsPredicate firstPredicate = new NameContainsKeyTermsPredicate(firstPredicateKeyTermList);
+        NameContainsKeyTermsPredicate secondPredicate = new NameContainsKeyTermsPredicate(secondPredicateKeyTermList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        NameContainsKeyTermsPredicate firstPredicateCopy = new NameContainsKeyTermsPredicate(firstPredicateKeyTermList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeyTerms_returnsTrue() {
+        // One keyword
+        NameContainsKeyTermsPredicate predicate = new NameContainsKeyTermsPredicate(Collections.singletonList("Alice"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Multiple keywords
+        predicate = new NameContainsKeyTermsPredicate(Arrays.asList("Alice", "Bob"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Only one matching keyword
+        predicate = new NameContainsKeyTermsPredicate(Arrays.asList("Bob", "Carol"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
+
+        // Mixed-case keywords
+        predicate = new NameContainsKeyTermsPredicate(Arrays.asList("aLIce", "bOB"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // One key term
+        predicate = new NameContainsKeyTermsPredicate(Collections.singletonList("Ali"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Multiple key terms
+        predicate = new NameContainsKeyTermsPredicate(Arrays.asList("lic", "ob"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Only one matching key term
+        predicate = new NameContainsKeyTermsPredicate(Arrays.asList("Bo", "arol"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
+
+        // Mixed-case key terms
+        predicate = new NameContainsKeyTermsPredicate(Arrays.asList("aL", "ce", "oB"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+        predicate = new NameContainsKeyTermsPredicate(Arrays.asList("Bo", "aRoL"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeyTerms_returnsFalse() {
+        // Zero keywords
+        NameContainsKeyTermsPredicate predicate = new NameContainsKeyTermsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
+
+        // Non-matching keyword
+        predicate = new NameContainsKeyTermsPredicate(Arrays.asList("Carol"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Keywords match phone and email, but does not match name
+        predicate = new NameContainsKeyTermsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhones(List.of("12345"))
+                .withEmails(List.of("alice@email.com")).build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keyTerms = List.of("keyterm1", "keyterm2");
+        NameContainsKeyTermsPredicate predicate = new NameContainsKeyTermsPredicate(keyTerms);
+
+        String expected = NameContainsKeyTermsPredicate.class.getCanonicalName() + "{key terms=" + keyTerms + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
Altered FindCommand to enable searching by part of contact's name (i.e. names do not have to match search terms word-for-word to be displayed by FindCommand)

Fixes #76 