### PR TITLE
Standardise CommandResult Messages to match the UG

### DIFF
--- a/src/main/java/networkbook/logic/Messages.java
+++ b/src/main/java/networkbook/logic/Messages.java
@@ -18,8 +18,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CONTACT_NAME = "Invalid name provided for contact to create!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "Here is your sorted list of contacts:"
-        + "\n(%1$d persons listed)";
+    public static final String MESSAGE_PERSONS_SORTED_OVERVIEW = "Here is your sorted list of contacts:"
+            + "\n(%1$d persons listed)";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/networkbook/logic/Messages.java
+++ b/src/main/java/networkbook/logic/Messages.java
@@ -18,7 +18,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CONTACT_NAME = "Invalid name provided for contact to create!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "Here is your sorted list of contacts: \n(%1$d persons listed)";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "Here is your sorted list of contacts:"
+        + "\n(%1$d persons listed)";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/networkbook/logic/Messages.java
+++ b/src/main/java/networkbook/logic/Messages.java
@@ -18,7 +18,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CONTACT_NAME = "Invalid name provided for contact to create!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "Here is your sorted list of contacts: \n(%1$d persons listed)";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/networkbook/logic/commands/ClearCommand.java
+++ b/src/main/java/networkbook/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import networkbook.model.NetworkBook;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "NetworkBook has been cleared!";
+    public static final String MESSAGE_SUCCESS = "Noted, cleared all contacts!";
 
 
     @Override

--- a/src/main/java/networkbook/logic/commands/CreateCommand.java
+++ b/src/main/java/networkbook/logic/commands/CreateCommand.java
@@ -35,7 +35,7 @@ public class CreateCommand extends Command {
             + CliSyntax.PREFIX_TAG + " owesMoney";
 
     public static final String MESSAGE_SUCCESS = "Noted, created new contact: \n%1$s";
-    public static final String MESSAGE_SUCCESS_INDEX = "\nat index ";
+    public static final String MESSAGE_SUCCESS_INDEX = "\nAt index %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This contact already exists in the network book";
 
     private final Person toAdd;
@@ -58,7 +58,7 @@ public class CreateCommand extends Command {
 
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd))
-            + MESSAGE_SUCCESS_INDEX + model.getFilteredPersonList().size());
+            + String.format(MESSAGE_SUCCESS_INDEX, model.getFilteredPersonList().size()));
     }
 
     @Override

--- a/src/main/java/networkbook/logic/commands/CreateCommand.java
+++ b/src/main/java/networkbook/logic/commands/CreateCommand.java
@@ -34,7 +34,8 @@ public class CreateCommand extends Command {
             + CliSyntax.PREFIX_TAG + " friends "
             + CliSyntax.PREFIX_TAG + " owesMoney";
 
-    public static final String MESSAGE_SUCCESS = "New contact created: %1$s";
+    public static final String MESSAGE_SUCCESS = "Noted, created new contact: \n%1$s";
+    public static final String MESSAGE_SUCCESS_INDEX = "\nat index ";
     public static final String MESSAGE_DUPLICATE_PERSON = "This contact already exists in the network book";
 
     private final Person toAdd;
@@ -56,7 +57,8 @@ public class CreateCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd))
+            + MESSAGE_SUCCESS_INDEX + model.getFilteredPersonList().size());
     }
 
     @Override

--- a/src/main/java/networkbook/logic/commands/DeleteCommand.java
+++ b/src/main/java/networkbook/logic/commands/DeleteCommand.java
@@ -24,7 +24,8 @@ public class DeleteCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Noted, deleted contact:\n%1$s";
+    public static final String MESSAGE_DELETE_PERSON_INDEX = "\nAt index %1$s";
 
     private final Index targetIndex;
 
@@ -43,7 +44,9 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete))
+                + String.format(MESSAGE_DELETE_PERSON_INDEX, targetIndex.getOneBased()));
     }
 
     @Override

--- a/src/main/java/networkbook/logic/commands/FindCommand.java
+++ b/src/main/java/networkbook/logic/commands/FindCommand.java
@@ -20,6 +20,7 @@ public class FindCommand extends Command {
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
     public static final String MESSAGE_SUCCESS = "Here is the list of contacts that contain %1$s:";
+    public static final String MESSAGE_PERSONS_FOUND_OVERVIEW = "\n(%1$s contacts found)";
 
     private final NameContainsKeyTermsPredicate predicate;
 
@@ -32,13 +33,13 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                // String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size())
                 String.format(MESSAGE_SUCCESS,
                         predicate.getKeyTerms()
                                 .stream()
                                 .reduce("", (acc, term) -> acc + " \"" + term + "\"")
                                 .trim()
-                                .replace(" ", ", ")));
+                                .replace(" ", ", "))
+                        + String.format(MESSAGE_PERSONS_FOUND_OVERVIEW, model.getFilteredPersonList().size()));
     }
 
     @Override

--- a/src/main/java/networkbook/logic/commands/FindCommand.java
+++ b/src/main/java/networkbook/logic/commands/FindCommand.java
@@ -20,6 +20,8 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
+    public static final String MESSAGE_SUCCESS = "Here is the list of contacts that contain %1$s:";
+
     private final NameContainsKeyTermsPredicate predicate;
 
     public FindCommand(NameContainsKeyTermsPredicate predicate) {
@@ -31,7 +33,14 @@ public class FindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                // String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size())
+                String.format(MESSAGE_SUCCESS,
+                        predicate.getKeyTerms()
+                                .stream()
+                                .reduce("", (acc, term) -> acc + " \"" + term + "\"")
+                                .toString()
+                                .trim()
+                                .replace(" ", ", ")));
     }
 
     @Override

--- a/src/main/java/networkbook/logic/commands/FindCommand.java
+++ b/src/main/java/networkbook/logic/commands/FindCommand.java
@@ -3,7 +3,6 @@ package networkbook.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import networkbook.commons.util.ToStringBuilder;
-import networkbook.logic.Messages;
 import networkbook.model.Model;
 import networkbook.model.person.NameContainsKeyTermsPredicate;
 
@@ -38,7 +37,6 @@ public class FindCommand extends Command {
                         predicate.getKeyTerms()
                                 .stream()
                                 .reduce("", (acc, term) -> acc + " \"" + term + "\"")
-                                .toString()
                                 .trim()
                                 .replace(" ", ", ")));
     }

--- a/src/main/java/networkbook/logic/commands/ListCommand.java
+++ b/src/main/java/networkbook/logic/commands/ListCommand.java
@@ -12,7 +12,7 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Here is your complete list of contacts:";
 
 
     @Override

--- a/src/main/java/networkbook/logic/commands/ListCommand.java
+++ b/src/main/java/networkbook/logic/commands/ListCommand.java
@@ -12,13 +12,14 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Here is your complete list of contacts:";
-
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "Here is your complete list of contacts:"
+            + "\n(%1$d persons listed)";
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(String.format(MESSAGE_PERSONS_LISTED_OVERVIEW,
+                model.getFilteredPersonList().size()));
     }
 }

--- a/src/main/java/networkbook/logic/commands/SortCommand.java
+++ b/src/main/java/networkbook/logic/commands/SortCommand.java
@@ -35,7 +35,7 @@ public class SortCommand extends Command {
         requireNonNull(model);
         model.updateSortedPersonList(comparator);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_SORTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
 
     @Override

--- a/src/main/java/networkbook/model/person/NameContainsKeyTermsPredicate.java
+++ b/src/main/java/networkbook/model/person/NameContainsKeyTermsPredicate.java
@@ -41,4 +41,8 @@ public class NameContainsKeyTermsPredicate implements Predicate<Person> {
     public String toString() {
         return new ToStringBuilder(this).add("key terms", keyTerms).toString();
     }
+
+    public List<String> getKeyTerms() {
+        return keyTerms;
+    }
 }

--- a/src/test/java/networkbook/logic/LogicManagerTest.java
+++ b/src/test/java/networkbook/logic/LogicManagerTest.java
@@ -62,7 +62,7 @@ public class LogicManagerTest {
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        assertCommandSuccess(listCommand, String.format(ListCommand.MESSAGE_PERSONS_LISTED_OVERVIEW, 0), model);
     }
 
     @Test

--- a/src/test/java/networkbook/logic/commands/CreateCommandIntegrationTest.java
+++ b/src/test/java/networkbook/logic/commands/CreateCommandIntegrationTest.java
@@ -32,7 +32,7 @@ public class CreateCommandIntegrationTest {
 
         CommandTestUtil.assertCommandSuccess(new CreateCommand(validPerson), model,
                 String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson))
-                    + CreateCommand.MESSAGE_SUCCESS_INDEX + expectedModel.getFilteredPersonList().size(),
+                    + String.format(CreateCommand.MESSAGE_SUCCESS_INDEX, expectedModel.getFilteredPersonList().size()),
                 expectedModel);
     }
 

--- a/src/test/java/networkbook/logic/commands/CreateCommandIntegrationTest.java
+++ b/src/test/java/networkbook/logic/commands/CreateCommandIntegrationTest.java
@@ -31,7 +31,8 @@ public class CreateCommandIntegrationTest {
         expectedModel.addPerson(validPerson);
 
         CommandTestUtil.assertCommandSuccess(new CreateCommand(validPerson), model,
-                String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+                String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson))
+                    + CreateCommand.MESSAGE_SUCCESS_INDEX + expectedModel.getFilteredPersonList().size(),
                 expectedModel);
     }
 

--- a/src/test/java/networkbook/logic/commands/CreateCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/CreateCommandTest.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import networkbook.commons.core.GuiSettings;
 import networkbook.logic.Messages;
@@ -40,7 +41,8 @@ public class CreateCommandTest {
 
         CommandResult commandResult = new CreateCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+        assertEquals(String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson))
+                        + "\nat index 1",
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }
@@ -152,7 +154,11 @@ public class CreateCommandTest {
 
         @Override
         public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
+            // Invoked during the create command test
+            // Emulate the addition of a new Person into the list
+            ObservableList<Person> listToFill = FXCollections.observableArrayList();
+            listToFill.add(new PersonBuilder().build());
+            return listToFill;
         }
 
         @Override

--- a/src/test/java/networkbook/logic/commands/CreateCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/CreateCommandTest.java
@@ -42,7 +42,7 @@ public class CreateCommandTest {
         CommandResult commandResult = new CreateCommand(validPerson).execute(modelStub);
 
         assertEquals(String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson))
-                        + "\nat index 1",
+                        + "\nAt index 1",
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }

--- a/src/test/java/networkbook/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/DeleteCommandTest.java
@@ -32,7 +32,8 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+                Messages.format(personToDelete))
+                + String.format(DeleteCommand.MESSAGE_DELETE_PERSON_INDEX, 1);
 
         ModelManager expectedModel = new ModelManager(model.getNetworkBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -56,7 +57,8 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+                Messages.format(personToDelete))
+                + String.format(DeleteCommand.MESSAGE_DELETE_PERSON_INDEX, 1);
 
         Model expectedModel = new ModelManager(model.getNetworkBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);

--- a/src/test/java/networkbook/logic/commands/FindCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/FindCommandTest.java
@@ -51,7 +51,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "");
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "")
+                + String.format(FindCommand.MESSAGE_PERSONS_FOUND_OVERVIEW, 0);
         NameContainsKeyTermsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -61,7 +62,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_singleUnmatchedKeyword_noPersonFound() {
-        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Ulfred\"");
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Ulfred\"")
+                + String.format(FindCommand.MESSAGE_PERSONS_FOUND_OVERVIEW, 0);
         NameContainsKeyTermsPredicate predicate = preparePredicate("Ulfred");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -71,7 +73,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleUnmatchedKeywords_noPersonFound() {
-        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Ulfred\", \"Snyder\"");
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Ulfred\", \"Snyder\"")
+                + String.format(FindCommand.MESSAGE_PERSONS_FOUND_OVERVIEW, 0);
         NameContainsKeyTermsPredicate predicate = preparePredicate("Ulfred  Snyder");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -81,7 +84,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_singleUniqueKeyword_matchingPersonFound() {
-        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Fiona\"");
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Fiona\"")
+                + String.format(FindCommand.MESSAGE_PERSONS_FOUND_OVERVIEW, 1);
         NameContainsKeyTermsPredicate predicate = preparePredicate("Fiona");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -94,7 +98,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleUniqueKeywords_matchingPersonFound() {
-        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Fiona\", \"Kunz\"");
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Fiona\", \"Kunz\"")
+                + String.format(FindCommand.MESSAGE_PERSONS_FOUND_OVERVIEW, 1);
         NameContainsKeyTermsPredicate predicate = preparePredicate("Fiona   Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -107,7 +112,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_singleSharedKeyword_multiplePersonsFound() {
-        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Ku\"");
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Ku\"")
+                + String.format(FindCommand.MESSAGE_PERSONS_FOUND_OVERVIEW, 2);
         NameContainsKeyTermsPredicate predicate = preparePredicate("Ku");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -120,7 +126,8 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Kurz\", \"Elle\", \"Kunz\"");
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Kurz\", \"Elle\", \"Kunz\"")
+                + String.format(FindCommand.MESSAGE_PERSONS_FOUND_OVERVIEW, 3);
         NameContainsKeyTermsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/networkbook/logic/commands/FindCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/FindCommandTest.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import networkbook.logic.Messages;
 import networkbook.model.Model;
 import networkbook.model.ModelManager;
 import networkbook.model.UserPrefs;
@@ -52,7 +51,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "");
         NameContainsKeyTermsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -62,7 +61,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_singleUnmatchedKeyword_noPersonFound() {
-        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Ulfred\"");
         NameContainsKeyTermsPredicate predicate = preparePredicate("Ulfred");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -72,7 +71,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleUnmatchedKeywords_noPersonFound() {
-        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Ulfred\", \"Snyder\"");
         NameContainsKeyTermsPredicate predicate = preparePredicate("Ulfred  Snyder");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -82,7 +81,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_singleUniqueKeyword_matchingPersonFound() {
-        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Fiona\"");
         NameContainsKeyTermsPredicate predicate = preparePredicate("Fiona");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -95,7 +94,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleUniqueKeywords_matchingPersonFound() {
-        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Fiona\", \"Kunz\"");
         NameContainsKeyTermsPredicate predicate = preparePredicate("Fiona   Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -108,7 +107,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_singleSharedKeyword_multiplePersonsFound() {
-        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Ku\"");
         NameContainsKeyTermsPredicate predicate = preparePredicate("Ku");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -121,7 +120,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, "\"Kurz\", \"Elle\", \"Kunz\"");
         NameContainsKeyTermsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/networkbook/logic/commands/ListCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/ListCommandTest.java
@@ -28,12 +28,16 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model,
+                String.format(ListCommand.MESSAGE_PERSONS_LISTED_OVERVIEW, 7),
+                expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, TypicalIndexes.INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model,
+                String.format(ListCommand.MESSAGE_PERSONS_LISTED_OVERVIEW, 7),
+                expectedModel);
     }
 }

--- a/src/test/java/networkbook/logic/commands/SortCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/SortCommandTest.java
@@ -55,7 +55,7 @@ public class SortCommandTest {
     public void execute_descendingNameSort_correctlySorted() {
         List<Person> expectedPersons = TypicalPersons.getTypicalPersons();
         Collections.reverse(expectedPersons);
-        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, expectedPersons.size());
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_SORTED_OVERVIEW, expectedPersons.size());
         PersonSortComparator comparator = new PersonSortComparator(SortField.NAME, SortOrder.DESCENDING);
         Model model = new ModelManager(TypicalPersons.getTypicalNetworkBook(), new UserPrefs());
         Model expectedModel = new ModelManager(TypicalPersons.getTypicalNetworkBook(), new UserPrefs());


### PR DESCRIPTION
## Current status of PR
* EditCommand and AddCommand are unchanged because the way they work in practice and the UG specification is very different
* FindCommand currently matches the specification in the UG, however, do we want to merge the current CommandResult with the UG's CommandResult? (Count the number of contacts that match + plus show keywords searched)

Fixes #72 