### PR TITLE
Fix link

### DIFF
--- a/src/main/java/networkbook/model/person/Link.java
+++ b/src/main/java/networkbook/model/person/Link.java
@@ -23,7 +23,10 @@ public class Link implements Identifiable<Link> {
     // regex adapted from https://regexr.com/3au3g
     private static final String DOMAIN_NAME_REGEX =
             "^(http://|https://)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9][a-z0-9-]{0,61}[a-z0-9]";
-    private static final String PATH_REGEX = "(/[\\w_-]*)*"; // Valid URI path
+
+    // reference: https://stackoverflow.com/questions/4669692
+    //          /valid-characters-for-directory-part-of-a-url-for-short-links
+    private static final String PATH_REGEX = "(/[a-zA-Z0-9_\\-.~!$&'()*+,;=:@]*)*"; // Valid URI path
 
     // regex reused from https://stackoverflow.com/questions/23959352/validate-url-query-string-with-regex
     private static final String QUERY_REGEX = "\\?([\\w-]+(=[\\w-]*)?(&[\\w-]+(=[\\w-]*)?)*)?";

--- a/src/test/java/networkbook/model/person/LinkTest.java
+++ b/src/test/java/networkbook/model/person/LinkTest.java
@@ -45,6 +45,8 @@ public class LinkTest {
         assertTrue(Link.isValidLink("www.stackoverflow.xn--com"));
         assertTrue(Link.isValidLink("example.com/test01"));
         assertTrue(Link.isValidLink("www.example.com/test01/test02"));
+        assertTrue(Link.isValidLink("google.com/quack-quack"));
+        assertTrue(Link.isValidLink("google.com/index.html"));
         assertTrue(Link.isValidLink("https://www.pythonanywhere.com/user/test_underscore/"));
         assertTrue(Link.isValidLink("https://www.google.com/?q=haha"));
         assertTrue(Link.isValidLink("https://www.google.com?q=haha"));


### PR DESCRIPTION
Link with `.` in pathname is allowed,
along with some other characters.