### PR TITLE
Fix bug in OpenEmailCommand

### DIFF
--- a/src/main/java/networkbook/logic/commands/OpenEmailCommand.java
+++ b/src/main/java/networkbook/logic/commands/OpenEmailCommand.java
@@ -39,6 +39,7 @@ public class OpenEmailCommand extends Command {
      * @param emailIndex The index of the email in the email list of the person.
      */
     public OpenEmailCommand(Index personIndex, Index emailIndex) {
+        super(false);
         requireAllNonNull(personIndex, emailIndex);
         this.personIndex = personIndex;
         this.emailIndex = emailIndex;


### PR DESCRIPTION
Command constructor was modified to take in an extra boolean value, causing compile error for OpenEmailCommand. I have added a `super()` call that includes the boolean.