### PR TITLE
Fix malform json

### DIFF
--- a/src/main/java/networkbook/MainApp.java
+++ b/src/main/java/networkbook/MainApp.java
@@ -161,7 +161,6 @@ public class MainApp extends Application {
                 logger.info("Creating new preference file " + prefsFilePath);
             }
             initializedPrefs = prefsOptional.orElse(new UserPrefs());
-            System.out.println(initializedPrefs);
         } catch (DataLoadingException e) {
             logger.warning("Preference file at " + prefsFilePath + " could not be loaded."
                     + " Using default preferences.");

--- a/src/main/java/networkbook/MainApp.java
+++ b/src/main/java/networkbook/MainApp.java
@@ -11,6 +11,7 @@ import networkbook.commons.core.Config;
 import networkbook.commons.core.LogsCenter;
 import networkbook.commons.core.Version;
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.ConfigUtil;
 import networkbook.commons.util.StringUtil;
 import networkbook.logic.Logic;
@@ -88,6 +89,10 @@ public class MainApp extends Application {
             logger.warning("Data file at " + storage.getNetworkBookFilePath() + " could not be loaded."
                     + " Will be starting with an empty NetworkBook.");
             initialData = new NetworkBook();
+        } catch (NullValueException e) {
+            logger.warning(e.getMessage());
+            logger.warning("Starting with an empty NetworkBook.");
+            initialData = new NetworkBook();
         }
 
         return new ModelManager(initialData, userPrefs);
@@ -125,6 +130,10 @@ public class MainApp extends Application {
             logger.warning("Config file at " + configFilePathUsed + " could not be loaded."
                     + " Using default config properties.");
             initializedConfig = new Config();
+        } catch (NullValueException e) {
+            logger.warning(e.getMessage());
+            logger.warning("Using default config properties.");
+            initializedConfig = new Config();
         }
 
         //Update config file in case it was missing to begin with or there are new/unused fields
@@ -152,9 +161,14 @@ public class MainApp extends Application {
                 logger.info("Creating new preference file " + prefsFilePath);
             }
             initializedPrefs = prefsOptional.orElse(new UserPrefs());
+            System.out.println(initializedPrefs);
         } catch (DataLoadingException e) {
             logger.warning("Preference file at " + prefsFilePath + " could not be loaded."
                     + " Using default preferences.");
+            initializedPrefs = new UserPrefs();
+        } catch (NullValueException e) {
+            logger.warning(e.getMessage());
+            logger.warning("Using default preferences");
             initializedPrefs = new UserPrefs();
         }
 

--- a/src/main/java/networkbook/commons/core/Config.java
+++ b/src/main/java/networkbook/commons/core/Config.java
@@ -5,12 +5,14 @@ import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.logging.Level;
 
+import networkbook.commons.exceptions.NullValueException;
+import networkbook.commons.util.JsonObject;
 import networkbook.commons.util.ToStringBuilder;
 
 /**
  * Config values used by the app
  */
-public class Config {
+public class Config implements JsonObject {
 
     public static final Path DEFAULT_CONFIG_FILE = Paths.get("config.json");
 
@@ -32,6 +34,13 @@ public class Config {
 
     public void setUserPrefsFilePath(Path userPrefsFilePath) {
         this.userPrefsFilePath = userPrefsFilePath;
+    }
+
+    @Override
+    public void assertFieldsAreNotNull() throws NullValueException {
+        if (logLevel == null || userPrefsFilePath == null) {
+            throw new NullValueException();
+        }
     }
 
     @Override

--- a/src/main/java/networkbook/commons/exceptions/DuplicateEntryException.java
+++ b/src/main/java/networkbook/commons/exceptions/DuplicateEntryException.java
@@ -1,0 +1,10 @@
+package networkbook.commons.exceptions;
+
+/**
+ * Represents a checked error when there are duplicate entries within a list.
+ */
+public class DuplicateEntryException extends Exception {
+    public DuplicateEntryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/networkbook/commons/exceptions/NullValueException.java
+++ b/src/main/java/networkbook/commons/exceptions/NullValueException.java
@@ -1,5 +1,9 @@
 package networkbook.commons.exceptions;
 
+/**
+ * Represents a checked exception thrown when an object field that is not supposed to be null is null.
+ * This happens when reading from JSON.
+ */
 public class NullValueException extends IllegalValueException {
     public NullValueException() {
         super("Non-nullable field(s) should not be null");

--- a/src/main/java/networkbook/commons/exceptions/NullValueException.java
+++ b/src/main/java/networkbook/commons/exceptions/NullValueException.java
@@ -1,0 +1,7 @@
+package networkbook.commons.exceptions;
+
+public class NullValueException extends IllegalValueException {
+    public NullValueException() {
+        super("Non-nullable field(s) should not be null");
+    }
+}

--- a/src/main/java/networkbook/commons/util/ConfigUtil.java
+++ b/src/main/java/networkbook/commons/util/ConfigUtil.java
@@ -6,13 +6,14 @@ import java.util.Optional;
 
 import networkbook.commons.core.Config;
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 
 /**
  * A class for accessing the Config File.
  */
 public class ConfigUtil {
 
-    public static Optional<Config> readConfig(Path configFilePath) throws DataLoadingException {
+    public static Optional<Config> readConfig(Path configFilePath) throws DataLoadingException, NullValueException {
         return JsonUtil.readJsonFile(configFilePath, Config.class);
     }
 

--- a/src/main/java/networkbook/commons/util/JsonObject.java
+++ b/src/main/java/networkbook/commons/util/JsonObject.java
@@ -2,6 +2,11 @@ package networkbook.commons.util;
 
 import networkbook.commons.exceptions.NullValueException;
 
+/**
+ * Represents an object that can be transformed from a JSON.
+ * Classes that inherit this interface must implements {@code assertFieldsAreNotNull},
+ * to ensure that object fields not supposed to be null are not null.
+ */
 public interface JsonObject {
     /**
      * Asserts that all fields that are not supposed to be null are not null.

--- a/src/main/java/networkbook/commons/util/JsonObject.java
+++ b/src/main/java/networkbook/commons/util/JsonObject.java
@@ -1,0 +1,12 @@
+package networkbook.commons.util;
+
+import networkbook.commons.exceptions.NullValueException;
+
+public interface JsonObject {
+    /**
+     * Asserts that all fields that are not supposed to be null are not null.
+     * To be used in reading json file.
+     * @throws NullValueException If there is a null field.
+     */
+    void assertFieldsAreNotNull() throws NullValueException;
+}

--- a/src/main/java/networkbook/commons/util/JsonUtil.java
+++ b/src/main/java/networkbook/commons/util/JsonUtil.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 import networkbook.commons.core.LogsCenter;
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 
 /**
  * Converts a Java object instance to JSON and vice versa
@@ -43,8 +44,8 @@ public class JsonUtil {
         FileUtil.writeToFile(jsonFile, toJsonString(objectToSerialize));
     }
 
-    static <T> T deserializeObjectFromJsonFile(Path jsonFile, Class<T> classOfObjectToDeserialize)
-            throws IOException {
+    static <T extends JsonObject> T deserializeObjectFromJsonFile(Path jsonFile, Class<T> classOfObjectToDeserialize)
+            throws IOException, NullValueException {
         return fromJsonString(FileUtil.readFromFile(jsonFile), classOfObjectToDeserialize);
     }
 
@@ -56,8 +57,8 @@ public class JsonUtil {
      * @param classOfObjectToDeserialize JSON file has to correspond to the structure in the class given here.
      * @throws DataLoadingException if loading of the JSON file failed.
      */
-    public static <T> Optional<T> readJsonFile(
-            Path filePath, Class<T> classOfObjectToDeserialize) throws DataLoadingException {
+    public static <T extends JsonObject> Optional<T> readJsonFile(
+            Path filePath, Class<T> classOfObjectToDeserialize) throws DataLoadingException, NullValueException {
         requireNonNull(filePath);
 
         if (!Files.exists(filePath)) {
@@ -97,8 +98,11 @@ public class JsonUtil {
      * @param <T> The generic type to create an instance of
      * @return The instance of T with the specified values in the JSON string
      */
-    public static <T> T fromJsonString(String json, Class<T> instanceClass) throws IOException {
-        return objectMapper.readValue(json, instanceClass);
+    public static <T extends JsonObject> T fromJsonString(String json, Class<T> instanceClass)
+            throws IOException, NullValueException {
+        T value = objectMapper.readValue(json, instanceClass);
+        value.assertFieldsAreNotNull();
+        return value;
     }
 
     /**

--- a/src/main/java/networkbook/commons/util/JsonUtil.java
+++ b/src/main/java/networkbook/commons/util/JsonUtil.java
@@ -44,8 +44,8 @@ public class JsonUtil {
         FileUtil.writeToFile(jsonFile, toJsonString(objectToSerialize));
     }
 
-    private static <T extends JsonObject> T deserializeObjectFromJsonFile(Path jsonFile, Class<T> classOfObjectToDeserialize)
-            throws IOException, NullValueException {
+    private static <T extends JsonObject> T deserializeObjectFromJsonFile(
+            Path jsonFile, Class<T> classOfObjectToDeserialize) throws IOException, NullValueException {
         return fromJsonString(FileUtil.readFromFile(jsonFile), classOfObjectToDeserialize);
     }
 

--- a/src/main/java/networkbook/commons/util/JsonUtil.java
+++ b/src/main/java/networkbook/commons/util/JsonUtil.java
@@ -44,7 +44,7 @@ public class JsonUtil {
         FileUtil.writeToFile(jsonFile, toJsonString(objectToSerialize));
     }
 
-    static <T extends JsonObject> T deserializeObjectFromJsonFile(Path jsonFile, Class<T> classOfObjectToDeserialize)
+    private static <T extends JsonObject> T deserializeObjectFromJsonFile(Path jsonFile, Class<T> classOfObjectToDeserialize)
             throws IOException, NullValueException {
         return fromJsonString(FileUtil.readFromFile(jsonFile), classOfObjectToDeserialize);
     }
@@ -98,7 +98,7 @@ public class JsonUtil {
      * @param <T> The generic type to create an instance of
      * @return The instance of T with the specified values in the JSON string
      */
-    public static <T extends JsonObject> T fromJsonString(String json, Class<T> instanceClass)
+    private static <T extends JsonObject> T fromJsonString(String json, Class<T> instanceClass)
             throws IOException, NullValueException {
         T value = objectMapper.readValue(json, instanceClass);
         value.assertFieldsAreNotNull();

--- a/src/main/java/networkbook/model/UserPrefs.java
+++ b/src/main/java/networkbook/model/UserPrefs.java
@@ -7,11 +7,13 @@ import java.nio.file.Paths;
 import java.util.Objects;
 
 import networkbook.commons.core.GuiSettings;
+import networkbook.commons.exceptions.NullValueException;
+import networkbook.commons.util.JsonObject;
 
 /**
  * Represents User's preferences.
  */
-public class UserPrefs implements ReadOnlyUserPrefs {
+public class UserPrefs implements ReadOnlyUserPrefs, JsonObject {
 
     private GuiSettings guiSettings = new GuiSettings();
     private Path networkBookFilePath = Paths.get("data" , "networkbook.json");
@@ -54,6 +56,13 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void setNetworkBookFilePath(Path networkBookFilePath) {
         requireNonNull(networkBookFilePath);
         this.networkBookFilePath = networkBookFilePath;
+    }
+
+    @Override
+    public void assertFieldsAreNotNull() throws NullValueException {
+        if (guiSettings == null || networkBookFilePath == null) {
+            throw new NullValueException();
+        }
     }
 
     @Override

--- a/src/main/java/networkbook/model/UserPrefs.java
+++ b/src/main/java/networkbook/model/UserPrefs.java
@@ -45,7 +45,7 @@ public class UserPrefs implements ReadOnlyUserPrefs, JsonObject {
     }
 
     public void setGuiSettings(GuiSettings guiSettings) {
-        requireNonNull(guiSettings);
+        assert guiSettings != null;
         this.guiSettings = guiSettings;
     }
 
@@ -54,7 +54,7 @@ public class UserPrefs implements ReadOnlyUserPrefs, JsonObject {
     }
 
     public void setNetworkBookFilePath(Path networkBookFilePath) {
-        requireNonNull(networkBookFilePath);
+        assert networkBookFilePath != null;
         this.networkBookFilePath = networkBookFilePath;
     }
 

--- a/src/main/java/networkbook/model/person/Email.java
+++ b/src/main/java/networkbook/model/person/Email.java
@@ -30,7 +30,7 @@ public class Email implements Identifiable<Email> {
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     private final String value;

--- a/src/main/java/networkbook/storage/JsonAdaptedPerson.java
+++ b/src/main/java/networkbook/storage/JsonAdaptedPerson.java
@@ -29,7 +29,7 @@ import networkbook.model.util.UniqueList;
 class JsonAdaptedPerson implements JsonObject {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
-    private static final String DUPLICATE_ENTRY_MESSAGE = "Duplicate entry for %s found: %s";
+    public static final String DUPLICATE_ENTRY_MESSAGE = "Duplicate entry for %s found: %s";
 
     private final String name;
     private final List<JsonAdaptedProperty<Phone>> phones = new ArrayList<>();

--- a/src/main/java/networkbook/storage/JsonAdaptedPerson.java
+++ b/src/main/java/networkbook/storage/JsonAdaptedPerson.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import networkbook.commons.exceptions.DuplicateEntryException;
 import networkbook.commons.exceptions.IllegalValueException;
 import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.JsonObject;
@@ -28,6 +29,7 @@ import networkbook.model.util.UniqueList;
 class JsonAdaptedPerson implements JsonObject {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+    private static final String DUPLICATE_ENTRY_MESSAGE = "Duplicate entry for %s found: %s";
 
     private final String name;
     private final List<JsonAdaptedProperty<Phone>> phones = new ArrayList<>();
@@ -107,39 +109,68 @@ class JsonAdaptedPerson implements JsonObject {
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted person.
      */
-    public Person toModelType() throws IllegalValueException {
+    public Person toModelType() throws IllegalValueException, DuplicateEntryException {
+        final Name modelName = getModelName();
+        final UniqueList<Phone> modelPhones = getModelPhones();
+        final UniqueList<Email> modelEmails = getModelEmails();
+        final UniqueList<Link> modelLinks = getModelLinks();
+        final Graduation modelGraduation = getModelGraduation();
+        final UniqueList<Course> modelCourses = getModelCourses();
+        final UniqueList<Specialisation> modelSpecs = getModelSpecialisations();
+        final UniqueList<Tag> modelTags = getModelTags();
+        final Priority modelPriority = getModelPriority();
+
+        return new Person(modelName, modelPhones, modelEmails, modelLinks, modelGraduation, modelCourses,
+                modelSpecs, modelTags, modelPriority);
+    }
+
+    private Name getModelName() throws IllegalValueException {
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
         if (!Name.isValidName(name)) {
             throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
         }
-        final Name modelName = new Name(name);
+        return new Name(name);
+    }
 
-        if (!phones.stream()
-                .map(JsonAdaptedProperty::getName)
-                .allMatch(Phone::isValidPhone)) {
-            throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
-        }
+    private UniqueList<Phone> getModelPhones() throws IllegalValueException, DuplicateEntryException {
         final UniqueList<Phone> modelPhones = new UniqueList<>();
-        phones.forEach(phone -> modelPhones.add(new Phone(phone.getName())));
+        for (JsonAdaptedProperty<Phone> phone : phones) {
+            Phone toAdd = phone.toModelType(Phone::isValidPhone, Phone.MESSAGE_CONSTRAINTS, Phone::new);
+            if (modelPhones.contains(toAdd)) {
+                throw new DuplicateEntryException(String.format(DUPLICATE_ENTRY_MESSAGE, "phone", phone.getName()));
+            }
+            modelPhones.add(toAdd);
+        };
+        return modelPhones;
+    }
 
-        if (!emails.stream()
-                .map(JsonAdaptedProperty::getName)
-                .allMatch(Email::isValidEmail)) {
-            throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
-        }
+    private UniqueList<Email> getModelEmails() throws IllegalValueException, DuplicateEntryException {
         final UniqueList<Email> modelEmails = new UniqueList<>();
-        emails.forEach(email -> modelEmails.add(new Email(email.getName())));
-
-        if (!links.stream()
-                .map(JsonAdaptedProperty::getName)
-                .allMatch(Link::isValidLink)) {
-            throw new IllegalValueException(Link.MESSAGE_CONSTRAINTS);
+        for (JsonAdaptedProperty<Email> email : emails) {
+            Email toAdd = email.toModelType(Email::isValidEmail, Email.MESSAGE_CONSTRAINTS, Email::new);
+            if (modelEmails.contains(toAdd)) {
+                throw new DuplicateEntryException(String.format(DUPLICATE_ENTRY_MESSAGE, "email", email.getName()));
+            }
+            modelEmails.add(toAdd);
         }
-        final UniqueList<Link> modelLinks = new UniqueList<>();
-        links.forEach(link -> modelLinks.add(new Link(link.getName())));
+        return modelEmails;
+    }
 
+    private UniqueList<Link> getModelLinks() throws IllegalValueException, DuplicateEntryException {
+        final UniqueList<Link> modelLinks = new UniqueList<>();
+        for (JsonAdaptedProperty<Link> link : links) {
+            Link toAdd = link.toModelType(Link::isValidLink, Link.MESSAGE_CONSTRAINTS, Link::new);
+            if (modelLinks.contains(toAdd)) {
+                throw new DuplicateEntryException(String.format(DUPLICATE_ENTRY_MESSAGE, "link", link.getName()));
+            }
+            modelLinks.add(toAdd);
+        }
+        return modelLinks;
+    }
+
+    private Graduation getModelGraduation() throws IllegalValueException {
         Graduation modelGraduation = null;
         if (graduation != null) {
             if (!Graduation.isValidGraduation(graduation)) {
@@ -147,29 +178,49 @@ class JsonAdaptedPerson implements JsonObject {
             }
             modelGraduation = new Graduation(graduation);
         }
+        return modelGraduation;
+    }
 
-        Course modelCourse = null;
-        if (!courses.stream()
-                .map(JsonAdaptedProperty::getName)
-                .allMatch(Course::isValidCourse)) {
-            throw new IllegalValueException(Course.MESSAGE_CONSTRAINTS);
-        }
+    private UniqueList<Course> getModelCourses() throws IllegalValueException, DuplicateEntryException {
         final UniqueList<Course> modelCourses = new UniqueList<>();
-        courses.forEach(course -> modelCourses.add(new Course(course.getName())));
-
-        if (!specialisations.stream()
-                .map(JsonAdaptedProperty::getName)
-                .allMatch(Specialisation::isValidSpecialisation)) {
-            throw new IllegalValueException(Specialisation.MESSAGE_CONSTRAINTS);
+        for (JsonAdaptedProperty<Course> course : courses) {
+            Course toAdd = course.toModelType(Course::isValidCourse, Course.MESSAGE_CONSTRAINTS, Course::new);
+            if (modelCourses.contains(toAdd)) {
+                throw new DuplicateEntryException(String.format(DUPLICATE_ENTRY_MESSAGE, "course", course.getName()));
+            }
+            modelCourses.add(toAdd);
         }
-        final UniqueList<Specialisation> modelSpecs = new UniqueList<>();
-        specialisations.forEach(spec -> modelSpecs.add(new Specialisation(spec.getName())));
+        return modelCourses;
+    }
 
+    private UniqueList<Specialisation> getModelSpecialisations()
+            throws IllegalValueException, DuplicateEntryException {
+        final UniqueList<Specialisation> modelSpecs = new UniqueList<>();
+        for (JsonAdaptedProperty<Specialisation> specialisation : specialisations) {
+            Specialisation toAdd = specialisation.toModelType(Specialisation::isValidSpecialisation,
+                    Specialisation.MESSAGE_CONSTRAINTS, Specialisation::new);
+            if (modelSpecs.contains(toAdd)) {
+                throw new DuplicateEntryException(String.format(
+                        DUPLICATE_ENTRY_MESSAGE, "specialisation", specialisation.getName()));
+            }
+            modelSpecs.add(toAdd);
+        }
+        return modelSpecs;
+    }
+
+    private UniqueList<Tag> getModelTags() throws IllegalValueException, DuplicateEntryException {
         final UniqueList<Tag> modelTags = new UniqueList<>();
         for (JsonAdaptedProperty<Tag> tag : tags) {
-            modelTags.add(tag.toModelType(Tag::isValidTagName, Tag.MESSAGE_CONSTRAINTS, Tag::new));
+            Tag toAdd = tag.toModelType(Tag::isValidTagName, Tag.MESSAGE_CONSTRAINTS, Tag::new);
+            if (modelTags.contains(toAdd)) {
+                throw new DuplicateEntryException(String.format(DUPLICATE_ENTRY_MESSAGE, "tag", tag.getName()));
+            }
+            modelTags.add(toAdd);
         }
+        return modelTags;
+    }
 
+    private Priority getModelPriority() throws IllegalValueException {
         Priority modelPriority = null;
         if (priority != null) {
             if (!Priority.isValidPriority(Priority.parsePriorityLevel(priority))) {
@@ -177,9 +228,7 @@ class JsonAdaptedPerson implements JsonObject {
             }
             modelPriority = new Priority(priority);
         }
-
-        return new Person(modelName, modelPhones, modelEmails, modelLinks, modelGraduation, modelCourses,
-                modelSpecs, modelTags, modelPriority);
+        return modelPriority;
     }
 
     @Override

--- a/src/main/java/networkbook/storage/JsonAdaptedPerson.java
+++ b/src/main/java/networkbook/storage/JsonAdaptedPerson.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import networkbook.commons.exceptions.IllegalValueException;
+import networkbook.commons.exceptions.NullValueException;
+import networkbook.commons.util.JsonObject;
 import networkbook.model.person.Course;
 import networkbook.model.person.Email;
 import networkbook.model.person.Graduation;
@@ -23,7 +25,7 @@ import networkbook.model.util.UniqueList;
 /**
  * Jackson-friendly version of {@link Person}.
  */
-class JsonAdaptedPerson {
+class JsonAdaptedPerson implements JsonObject {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
 
@@ -180,4 +182,68 @@ class JsonAdaptedPerson {
                 modelSpecs, modelTags, modelPriority);
     }
 
+    @Override
+    public void assertFieldsAreNotNull() throws NullValueException {
+        assertNameIsNotNull();
+        assertPhonesAreNotNull();
+        assertEmailsAreNotNull();
+        assertLinksAreNotNull();
+        assertCoursesAreNotNull();
+        assertSpecialisationsAreNotNull();
+        assertTagsAreNotNull();
+    }
+
+    private void assertNameIsNotNull() throws NullValueException {
+        if (name == null) {
+            throw new NullValueException();
+        }
+    }
+
+    private void assertPhonesAreNotNull() throws NullValueException {
+        for (JsonAdaptedProperty<Phone> phone : phones) {
+            if (phone == null) {
+                throw new NullValueException();
+            }
+        }
+    }
+
+    private void assertEmailsAreNotNull() throws NullValueException {
+        for (JsonAdaptedProperty<Email> email : emails) {
+            if (email == null) {
+                throw new NullValueException();
+            }
+        }
+    }
+
+    private void assertLinksAreNotNull() throws NullValueException {
+        for (JsonAdaptedProperty<Link> link : links) {
+            if (link == null) {
+                throw new NullValueException();
+            }
+        }
+    }
+
+    private void assertCoursesAreNotNull() throws NullValueException {
+        for (JsonAdaptedProperty<Course> course : courses) {
+            if (course == null) {
+                throw new NullValueException();
+            }
+        }
+    }
+
+    private void assertSpecialisationsAreNotNull() throws NullValueException {
+        for (JsonAdaptedProperty<Specialisation> specialisation : specialisations) {
+            if (specialisation == null) {
+                throw new NullValueException();
+            }
+        }
+    }
+
+    private void assertTagsAreNotNull() throws NullValueException {
+        for (JsonAdaptedProperty<Tag> tag : tags) {
+            if (tag == null) {
+                throw new NullValueException();
+            }
+        }
+    }
 }

--- a/src/main/java/networkbook/storage/JsonNetworkBookStorage.java
+++ b/src/main/java/networkbook/storage/JsonNetworkBookStorage.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 import networkbook.commons.core.LogsCenter;
 import networkbook.commons.exceptions.DataLoadingException;
 import networkbook.commons.exceptions.IllegalValueException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.FileUtil;
 import networkbook.commons.util.JsonUtil;
 import networkbook.model.ReadOnlyNetworkBook;
@@ -32,7 +33,7 @@ public class JsonNetworkBookStorage implements NetworkBookStorage {
     }
 
     @Override
-    public Optional<ReadOnlyNetworkBook> readNetworkBook() throws DataLoadingException {
+    public Optional<ReadOnlyNetworkBook> readNetworkBook() throws DataLoadingException, NullValueException {
         return readNetworkBook(filePath);
     }
 
@@ -42,7 +43,8 @@ public class JsonNetworkBookStorage implements NetworkBookStorage {
      * @param filePath location of the data. Cannot be null.
      * @throws DataLoadingException if loading the data from storage failed.
      */
-    public Optional<ReadOnlyNetworkBook> readNetworkBook(Path filePath) throws DataLoadingException {
+    public Optional<ReadOnlyNetworkBook> readNetworkBook(Path filePath)
+            throws DataLoadingException, NullValueException {
         requireNonNull(filePath);
 
         Optional<JsonSerializableNetworkBook> jsonNetworkBook = JsonUtil.readJsonFile(

--- a/src/main/java/networkbook/storage/JsonNetworkBookStorage.java
+++ b/src/main/java/networkbook/storage/JsonNetworkBookStorage.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 
 import networkbook.commons.core.LogsCenter;
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.DuplicateEntryException;
 import networkbook.commons.exceptions.IllegalValueException;
 import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.FileUtil;
@@ -58,6 +59,9 @@ public class JsonNetworkBookStorage implements NetworkBookStorage {
         } catch (IllegalValueException ive) {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataLoadingException(ive);
+        } catch (DuplicateEntryException dee) {
+            logger.info("Duplicate entry in " + filePath + ": " + dee.getMessage());
+            throw new DataLoadingException(dee);
         }
     }
 

--- a/src/main/java/networkbook/storage/JsonNetworkBookStorage.java
+++ b/src/main/java/networkbook/storage/JsonNetworkBookStorage.java
@@ -35,6 +35,7 @@ public class JsonNetworkBookStorage implements NetworkBookStorage {
 
     @Override
     public Optional<ReadOnlyNetworkBook> readNetworkBook() throws DataLoadingException, NullValueException {
+        assert filePath != null;
         return readNetworkBook(filePath);
     }
 
@@ -46,7 +47,7 @@ public class JsonNetworkBookStorage implements NetworkBookStorage {
      */
     public Optional<ReadOnlyNetworkBook> readNetworkBook(Path filePath)
             throws DataLoadingException, NullValueException {
-        requireNonNull(filePath);
+        assert filePath != null;
 
         Optional<JsonSerializableNetworkBook> jsonNetworkBook = JsonUtil.readJsonFile(
                 filePath, JsonSerializableNetworkBook.class);

--- a/src/main/java/networkbook/storage/JsonSerializableNetworkBook.java
+++ b/src/main/java/networkbook/storage/JsonSerializableNetworkBook.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import networkbook.commons.exceptions.DuplicateEntryException;
 import networkbook.commons.exceptions.IllegalValueException;
 import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.JsonObject;
@@ -47,7 +48,7 @@ class JsonSerializableNetworkBook implements JsonObject {
      *
      * @throws IllegalValueException if there were any data constraints violated.
      */
-    public NetworkBook toModelType() throws IllegalValueException {
+    public NetworkBook toModelType() throws IllegalValueException, DuplicateEntryException {
         NetworkBook networkBook = new NetworkBook();
         for (JsonAdaptedPerson jsonAdaptedPerson : persons) {
             Person person = jsonAdaptedPerson.toModelType();

--- a/src/main/java/networkbook/storage/JsonSerializableNetworkBook.java
+++ b/src/main/java/networkbook/storage/JsonSerializableNetworkBook.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import networkbook.commons.exceptions.IllegalValueException;
+import networkbook.commons.exceptions.NullValueException;
+import networkbook.commons.util.JsonObject;
 import networkbook.model.NetworkBook;
 import networkbook.model.ReadOnlyNetworkBook;
 import networkbook.model.person.Person;
@@ -17,7 +19,7 @@ import networkbook.model.person.Person;
  * An Immutable NetworkBook that is serializable to JSON format.
  */
 @JsonRootName(value = "networkbook")
-class JsonSerializableNetworkBook {
+class JsonSerializableNetworkBook implements JsonObject {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
 
@@ -57,4 +59,13 @@ class JsonSerializableNetworkBook {
         return networkBook;
     }
 
+    @Override
+    public void assertFieldsAreNotNull() throws NullValueException {
+        for (JsonAdaptedPerson person : persons) {
+            if (person == null) {
+                throw new NullValueException();
+            }
+            person.assertFieldsAreNotNull();
+        }
+    }
 }

--- a/src/main/java/networkbook/storage/JsonUserPrefsStorage.java
+++ b/src/main/java/networkbook/storage/JsonUserPrefsStorage.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.JsonUtil;
 import networkbook.model.ReadOnlyUserPrefs;
 import networkbook.model.UserPrefs;
@@ -26,7 +27,7 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
     }
 
     @Override
-    public Optional<UserPrefs> readUserPrefs() throws DataLoadingException {
+    public Optional<UserPrefs> readUserPrefs() throws DataLoadingException, NullValueException {
         return readUserPrefs(filePath);
     }
 
@@ -35,7 +36,7 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
      * @param prefsFilePath location of the data. Cannot be null.
      * @throws DataLoadingException if the file format is not as expected.
      */
-    public Optional<UserPrefs> readUserPrefs(Path prefsFilePath) throws DataLoadingException {
+    public Optional<UserPrefs> readUserPrefs(Path prefsFilePath) throws DataLoadingException, NullValueException {
         return JsonUtil.readJsonFile(prefsFilePath, UserPrefs.class);
     }
 

--- a/src/main/java/networkbook/storage/NetworkBookStorage.java
+++ b/src/main/java/networkbook/storage/NetworkBookStorage.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.model.NetworkBook;
 import networkbook.model.ReadOnlyNetworkBook;
 
@@ -24,12 +25,12 @@ public interface NetworkBookStorage {
      *
      * @throws DataLoadingException if loading the data from storage failed.
      */
-    Optional<ReadOnlyNetworkBook> readNetworkBook() throws DataLoadingException;
+    Optional<ReadOnlyNetworkBook> readNetworkBook() throws DataLoadingException, NullValueException;
 
     /**
      * @see #getNetworkBookFilePath()
      */
-    Optional<ReadOnlyNetworkBook> readNetworkBook(Path filePath) throws DataLoadingException;
+    Optional<ReadOnlyNetworkBook> readNetworkBook(Path filePath) throws DataLoadingException, NullValueException;
 
     /**
      * Saves the given {@link ReadOnlyNetworkBook} to the storage.

--- a/src/main/java/networkbook/storage/Storage.java
+++ b/src/main/java/networkbook/storage/Storage.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.model.ReadOnlyNetworkBook;
 import networkbook.model.ReadOnlyUserPrefs;
 import networkbook.model.UserPrefs;
@@ -15,7 +16,7 @@ import networkbook.model.UserPrefs;
 public interface Storage extends NetworkBookStorage, UserPrefsStorage {
 
     @Override
-    Optional<UserPrefs> readUserPrefs() throws DataLoadingException;
+    Optional<UserPrefs> readUserPrefs() throws DataLoadingException, NullValueException;
 
     @Override
     void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException;
@@ -24,7 +25,7 @@ public interface Storage extends NetworkBookStorage, UserPrefsStorage {
     Path getNetworkBookFilePath();
 
     @Override
-    Optional<ReadOnlyNetworkBook> readNetworkBook() throws DataLoadingException;
+    Optional<ReadOnlyNetworkBook> readNetworkBook() throws DataLoadingException, NullValueException;
 
     @Override
     void saveNetworkBook(ReadOnlyNetworkBook networkBook) throws IOException;

--- a/src/main/java/networkbook/storage/StorageManager.java
+++ b/src/main/java/networkbook/storage/StorageManager.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 
 import networkbook.commons.core.LogsCenter;
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.model.ReadOnlyNetworkBook;
 import networkbook.model.ReadOnlyUserPrefs;
 import networkbook.model.UserPrefs;
@@ -36,7 +37,7 @@ public class StorageManager implements Storage {
     }
 
     @Override
-    public Optional<UserPrefs> readUserPrefs() throws DataLoadingException {
+    public Optional<UserPrefs> readUserPrefs() throws DataLoadingException, NullValueException {
         return userPrefsStorage.readUserPrefs();
     }
 
@@ -54,12 +55,13 @@ public class StorageManager implements Storage {
     }
 
     @Override
-    public Optional<ReadOnlyNetworkBook> readNetworkBook() throws DataLoadingException {
+    public Optional<ReadOnlyNetworkBook> readNetworkBook() throws DataLoadingException, NullValueException {
         return readNetworkBook(networkBookStorage.getNetworkBookFilePath());
     }
 
     @Override
-    public Optional<ReadOnlyNetworkBook> readNetworkBook(Path filePath) throws DataLoadingException {
+    public Optional<ReadOnlyNetworkBook> readNetworkBook(Path filePath)
+            throws DataLoadingException, NullValueException {
         logger.fine("Attempting to read data from file: " + filePath);
         return networkBookStorage.readNetworkBook(filePath);
     }

--- a/src/main/java/networkbook/storage/UserPrefsStorage.java
+++ b/src/main/java/networkbook/storage/UserPrefsStorage.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.model.ReadOnlyUserPrefs;
 import networkbook.model.UserPrefs;
 
@@ -24,7 +25,7 @@ public interface UserPrefsStorage {
      *
      * @throws DataLoadingException if the loading of data from preference file failed.
      */
-    Optional<UserPrefs> readUserPrefs() throws DataLoadingException;
+    Optional<UserPrefs> readUserPrefs() throws DataLoadingException, NullValueException;
 
     /**
      * Saves the given {@link ReadOnlyUserPrefs} to the storage.

--- a/src/test/data/ConfigUtilTest/nullLogLevel.json
+++ b/src/test/data/ConfigUtilTest/nullLogLevel.json
@@ -1,0 +1,4 @@
+{
+  "logLevel" : null,
+  "userPrefsFilePath" : "preferences.json"
+}

--- a/src/test/data/ConfigUtilTest/nullUserPrefsFilePath.json
+++ b/src/test/data/ConfigUtilTest/nullUserPrefsFilePath.json
@@ -1,0 +1,4 @@
+{
+  "logLevel" : "INFO",
+  "userPrefsFilePath" : null
+}

--- a/src/test/data/JsonNetworkBookStorageTest/networkBookWithPersonContainingDuplicatePhones.json
+++ b/src/test/data/JsonNetworkBookStorageTest/networkBookWithPersonContainingDuplicatePhones.json
@@ -1,0 +1,12 @@
+{
+  "persons": [ {
+    "name": "Hans",
+    "phones": [ "9482424", "9482424" ],
+    "emails": [ "hans@example.com" ],
+    "links": [ "hahahans.com" ],
+    "graduation": "AY2324-S1",
+    "course": "Computer Science",
+    "specialisation": "Programming Languages",
+    "tags": [ "friends" ]
+  } ]
+}

--- a/src/test/data/JsonNetworkBookStorageTest/networkBookWithPersonContainingNullPhone.json
+++ b/src/test/data/JsonNetworkBookStorageTest/networkBookWithPersonContainingNullPhone.json
@@ -1,0 +1,12 @@
+{
+  "persons": [ {
+    "name": "Hans",
+    "phones": [ null ],
+    "emails": [ "hans@example.com" ],
+    "links": [ "hahahans.com" ],
+    "graduation": "AY2324-S1",
+    "course": "Computer Science",
+    "specialisation": "Programming Languages",
+    "tags": [ "friends" ]
+  } ]
+}

--- a/src/test/data/JsonSerializableNetworkBookTest/duplicatePersonNetworkBook.json
+++ b/src/test/data/JsonSerializableNetworkBookTest/duplicatePersonNetworkBook.json
@@ -5,8 +5,8 @@
     "emails": [ "alice@example.com" ],
     "links": [ "paulice.sg" ],
     "graduation": "AY2324-S1",
-    "course": "Computer Science",
-    "specialisation": "Software Engineering",
+    "courses": [ "Computer Science" ],
+    "specialisations": [ "Software Engineering" ],
     "tags": [ "friends" ]
   }, {
     "name": "Alice Pauline",
@@ -14,8 +14,8 @@
     "emails": [ "pauline@example.com" ],
     "links": [ "paulice.sg" ],
     "graduation": "AY2324-S1",
-    "course": "Computer Science",
-    "specialisation": "Software Engineering",
+    "courses": [ "Computer Science" ],
+    "specialisations": [ "Software Engineering" ],
     "tags": [ "friends" ]
   } ]
 }

--- a/src/test/data/JsonSerializableNetworkBookTest/personWithDuplicatePhones.json
+++ b/src/test/data/JsonSerializableNetworkBookTest/personWithDuplicatePhones.json
@@ -1,8 +1,8 @@
 {
   "persons": [ {
     "name": "Hans Muster",
-    "phones": [ "9482424" ],
-    "emails": [ "invalid@email!3e" ],
+    "phones": [ "9482424", "9482424" ],
+    "emails": [ "valid@email.com" ],
     "links": [ "hahahans.com" ],
     "graduation": "AY2324-S1",
     "courses": [ "Computer Science" ],

--- a/src/test/data/JsonSerializableNetworkBookTest/personWithNullName.json
+++ b/src/test/data/JsonSerializableNetworkBookTest/personWithNullName.json
@@ -1,8 +1,8 @@
 {
   "persons": [ {
-    "name": "Hans Muster",
+    "name": null,
     "phones": [ "9482424" ],
-    "emails": [ "invalid@email!3e" ],
+    "emails": [ "valid@email.com" ],
     "links": [ "hahahans.com" ],
     "graduation": "AY2324-S1",
     "courses": [ "Computer Science" ],

--- a/src/test/data/JsonSerializableNetworkBookTest/personWithNullPhone.json
+++ b/src/test/data/JsonSerializableNetworkBookTest/personWithNullPhone.json
@@ -1,8 +1,8 @@
 {
   "persons": [ {
     "name": "Hans Muster",
-    "phones": [ "9482424" ],
-    "emails": [ "invalid@email!3e" ],
+    "phones": [ null, "12345" ],
+    "emails": [ "valid@email.com" ],
     "links": [ "hahahans.com" ],
     "graduation": "AY2324-S1",
     "courses": [ "Computer Science" ],

--- a/src/test/data/JsonUserPrefsStorageTest/nullGuiSettingsUserPrefs.json
+++ b/src/test/data/JsonUserPrefsStorageTest/nullGuiSettingsUserPrefs.json
@@ -1,0 +1,4 @@
+{
+  "guiSettings" : null,
+  "networkBookFilePath" : "networkbook.json"
+}

--- a/src/test/data/JsonUserPrefsStorageTest/nullNetworkBookFilePathUserPrefs.json
+++ b/src/test/data/JsonUserPrefsStorageTest/nullNetworkBookFilePathUserPrefs.json
@@ -1,0 +1,12 @@
+{
+  "guiSettings" : {
+    "windowWidth" : 1000.0,
+    "windowHeight" : 500.0,
+    "windowCoordinates" : {
+      "x" : 300,
+      "y" : 100,
+      "z" : 99
+    }
+  },
+  "networkBookFilePath" : null
+}

--- a/src/test/java/networkbook/commons/util/ConfigUtilTest.java
+++ b/src/test/java/networkbook/commons/util/ConfigUtilTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import networkbook.commons.core.Config;
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 
 public class ConfigUtilTest {
 
@@ -29,7 +30,7 @@ public class ConfigUtilTest {
     }
 
     @Test
-    public void read_missingFile_emptyResult() throws DataLoadingException {
+    public void read_missingFile_emptyResult() throws Exception {
         assertFalse(read("NonExistentFile.json").isPresent());
     }
 
@@ -39,7 +40,7 @@ public class ConfigUtilTest {
     }
 
     @Test
-    public void read_fileInOrder_successfullyRead() throws DataLoadingException {
+    public void read_fileInOrder_successfullyRead() throws Exception {
 
         Config expected = getTypicalConfig();
 
@@ -48,17 +49,27 @@ public class ConfigUtilTest {
     }
 
     @Test
-    public void read_valuesMissingFromFile_defaultValuesUsed() throws DataLoadingException {
+    public void read_valuesMissingFromFile_defaultValuesUsed() throws Exception {
         Config actual = read("EmptyConfig.json").get();
         assertEquals(new Config(), actual);
     }
 
     @Test
-    public void read_extraValuesInFile_extraValuesIgnored() throws DataLoadingException {
+    public void read_extraValuesInFile_extraValuesIgnored() throws Exception {
         Config expected = getTypicalConfig();
         Config actual = read("ExtraValuesConfig.json").get();
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void read_nullLogLevel_throwsNullValueException() {
+        assertThrows(NullValueException.class, () -> read("nullLogLevel.json"));
+    }
+
+    @Test
+    public void read_nullUserPrefsFilePath_throwsNullValueException() throws Exception {
+        assertThrows(NullValueException.class, () -> read("nullUserPrefsFilePath.json"));
     }
 
     private Config getTypicalConfig() {
@@ -68,7 +79,7 @@ public class ConfigUtilTest {
         return config;
     }
 
-    private Optional<Config> read(String configFileInTestDataFolder) throws DataLoadingException {
+    private Optional<Config> read(String configFileInTestDataFolder) throws Exception {
         Path configFilePath = addToTestDataPathIfNotNull(configFileInTestDataFolder);
         return ConfigUtil.readConfig(configFilePath);
     }
@@ -84,7 +95,7 @@ public class ConfigUtilTest {
     }
 
     @Test
-    public void saveConfig_allInOrder_success() throws DataLoadingException, IOException {
+    public void saveConfig_allInOrder_success() throws Exception {
         Config original = getTypicalConfig();
 
         Path configFilePath = tempDir.resolve("TempConfig.json");

--- a/src/test/java/networkbook/commons/util/JsonUtilTest.java
+++ b/src/test/java/networkbook/commons/util/JsonUtilTest.java
@@ -1,12 +1,14 @@
 package networkbook.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.testutil.SerializableTestClass;
 import networkbook.testutil.TestUtil;
 
@@ -16,6 +18,7 @@ import networkbook.testutil.TestUtil;
 public class JsonUtilTest {
 
     private static final Path SERIALIZATION_FILE = TestUtil.getFilePathInSandboxFolder("serialize.json");
+    private static final Path EMPTY_FILE = TestUtil.getFilePathInSandboxFolder("empty.json");
 
     @Test
     public void serializeObjectToJsonFile_noExceptionThrown() throws IOException {
@@ -28,18 +31,23 @@ public class JsonUtilTest {
     }
 
     @Test
-    public void deserializeObjectFromJsonFile_noExceptionThrown() throws IOException {
+    public void readJsonFile_fileWithValidContent_noExceptionThrown() throws Exception {
         FileUtil.writeToFile(SERIALIZATION_FILE, SerializableTestClass.JSON_STRING_REPRESENTATION);
 
         SerializableTestClass serializableTestClass = JsonUtil
-                .deserializeObjectFromJsonFile(SERIALIZATION_FILE, SerializableTestClass.class);
+                .readJsonFile(SERIALIZATION_FILE, SerializableTestClass.class).get();
 
         assertEquals(serializableTestClass.getName(), SerializableTestClass.getNameTestValue());
         assertEquals(serializableTestClass.getListOfLocalDateTimes(), SerializableTestClass.getListTestValues());
         assertEquals(serializableTestClass.getMapOfIntegerToString(), SerializableTestClass.getHashMapTestValues());
     }
 
-    //TODO: @Test jsonUtil_readJsonStringToObjectInstance_correctObject()
-
-    //TODO: @Test jsonUtil_writeThenReadObjectToJson_correctObject()
+    @Test
+    public void readJsonFile_failToAssertNull_throwsNullValueException() throws Exception {
+        FileUtil.writeToFile(EMPTY_FILE, "{}");
+        JsonObject jsonObject = () -> {
+            throw new NullValueException();
+        };
+        assertThrows(NullValueException.class, () -> JsonUtil.readJsonFile(EMPTY_FILE, jsonObject.getClass()).get());
+    }
 }

--- a/src/test/java/networkbook/model/UserPrefsTest.java
+++ b/src/test/java/networkbook/model/UserPrefsTest.java
@@ -1,21 +1,21 @@
 package networkbook.model;
 
-import static networkbook.testutil.Assert.assertThrows;
+import static networkbook.testutil.Assert.assertThrowsAssertionError;
 
 import org.junit.jupiter.api.Test;
 
 public class UserPrefsTest {
 
     @Test
-    public void setGuiSettings_nullGuiSettings_throwsNullPointerException() {
+    public void setGuiSettings_nullGuiSettings_throwsAssertionError() {
         UserPrefs userPref = new UserPrefs();
-        assertThrows(NullPointerException.class, () -> userPref.setGuiSettings(null));
+        assertThrowsAssertionError(() -> userPref.setGuiSettings(null));
     }
 
     @Test
-    public void setNetworkBookFilePath_nullPath_throwsNullPointerException() {
+    public void setNetworkBookFilePath_nullPath_throwsAssertionError() {
         UserPrefs userPrefs = new UserPrefs();
-        assertThrows(NullPointerException.class, () -> userPrefs.setNetworkBookFilePath(null));
+        assertThrowsAssertionError(() -> userPrefs.setNetworkBookFilePath(null));
     }
 
 }

--- a/src/test/java/networkbook/model/person/EmailTest.java
+++ b/src/test/java/networkbook/model/person/EmailTest.java
@@ -36,6 +36,8 @@ public class EmailTest {
 
         // invalid parts
         assertFalse(Email.isValidEmail("peterjack@-")); // invalid domain name
+        assertFalse(Email.isValidEmail("test@example")); // domain must contain at least one '.'
+        assertFalse(Email.isValidEmail("test@example.c")); // last domain label is too short
         assertFalse(Email.isValidEmail("peterjack@exam_ple.com")); // underscore in domain name
         assertFalse(Email.isValidEmail("peter jack@example.com")); // spaces in local part
         assertFalse(Email.isValidEmail("peterjack@exam ple.com")); // spaces in domain name
@@ -58,9 +60,8 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
+        assertTrue(Email.isValidEmail("a@g.bc")); // minimal
+        assertTrue(Email.isValidEmail("123@145.67")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
@@ -69,10 +70,10 @@ public class EmailTest {
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("valid@email.com");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("valid@email.com")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -84,7 +85,7 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@email.com")));
     }
 
     @Test

--- a/src/test/java/networkbook/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/networkbook/storage/JsonAdaptedPersonTest.java
@@ -122,7 +122,7 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void assertFieldsAreNotNull_linksContainNull_throwsNullValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,CONTAINING_NULL_LINKS,
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, CONTAINING_NULL_LINKS,
                 VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
         assertThrows(NullValueException.class, person::assertFieldsAreNotNull);
     }

--- a/src/test/java/networkbook/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/networkbook/storage/JsonAdaptedPersonTest.java
@@ -2,44 +2,79 @@ package networkbook.storage;
 
 import static networkbook.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import networkbook.commons.exceptions.DuplicateEntryException;
 import networkbook.commons.exceptions.IllegalValueException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.model.person.Course;
 import networkbook.model.person.Email;
 import networkbook.model.person.Graduation;
 import networkbook.model.person.Link;
 import networkbook.model.person.Name;
+import networkbook.model.person.Person;
 import networkbook.model.person.Phone;
 import networkbook.model.person.Specialisation;
 import networkbook.model.person.Tag;
+import networkbook.testutil.PersonBuilder;
 import networkbook.testutil.TypicalPersons;
 
 // TODO: add/amend tests based on individual attribute specification
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
+    private static final String NULL_NAME = null;
     private static final List<JsonAdaptedProperty<Phone>> INVALID_PHONES = List.of(
             new JsonAdaptedProperty<>("+ 651234"));
+    private static final List<JsonAdaptedProperty<Phone>> CONTAINING_NULL_PHONES =
+            Stream.<JsonAdaptedProperty<Phone>>generate(() -> null)
+                    .limit(1).collect(Collectors.toCollection(ArrayList::new));
+    private static final List<JsonAdaptedProperty<Phone>> CONTAINING_DUPLICATE_PHONES = List.of(
+            new JsonAdaptedProperty<>("12345"), new JsonAdaptedProperty<>("12345"));
     private static final List<JsonAdaptedProperty<Email>> INVALID_EMAILS =
             List.of(new JsonAdaptedProperty<>("example.com"));
+    private static final List<JsonAdaptedProperty<Email>> CONTAINING_NULL_EMAILS =
+            Stream.<JsonAdaptedProperty<Email>>generate(() -> null)
+                    .limit(1).collect(Collectors.toCollection(ArrayList::new));
+    private static final List<JsonAdaptedProperty<Email>> CONTAINING_DUPLICATE_EMAILS = List.of(
+            new JsonAdaptedProperty<>("nkn@example.com"), new JsonAdaptedProperty<>("nkn@example.com"));
     private static final List<JsonAdaptedProperty<Link>> INVALID_LINKS = List.of(
-            new JsonAdaptedProperty<>("facebookcom")
-    );
+            new JsonAdaptedProperty<>("facebookcom"));
+    private static final List<JsonAdaptedProperty<Link>> CONTAINING_NULL_LINKS =
+            Stream.<JsonAdaptedProperty<Link>>generate(() -> null)
+                    .limit(1).collect(Collectors.toCollection(ArrayList::new));
+    private static final List<JsonAdaptedProperty<Link>> CONTAINING_DUPLICATE_LINKS = List.of(
+            new JsonAdaptedProperty<>("example.com"), new JsonAdaptedProperty<>("example.com"));
     private static final String INVALID_GRADUATION = "2024";
+    private static final String NULL_GRADUATION = null;
     private static final List<JsonAdaptedProperty<Course>> INVALID_COURSES = List.of(
-            new JsonAdaptedProperty<>("")
-    );
-    private static final List<JsonAdaptedProperty<Specialisation>> INVALID_SPECIALISATION = List.of(
-            new JsonAdaptedProperty<Specialisation>("")
-    );
-    private static final String INVALID_TAG = "#friend";
+            new JsonAdaptedProperty<>(""));
+    private static final List<JsonAdaptedProperty<Course>> CONTAINING_NULL_COURSES =
+            Stream.<JsonAdaptedProperty<Course>>generate(() -> null)
+                    .limit(1).collect(Collectors.toCollection(ArrayList::new));
+    private static final List<JsonAdaptedProperty<Course>> CONTAINING_DUPLICATE_COURSES = List.of(
+            new JsonAdaptedProperty<>("CS2103T"), new JsonAdaptedProperty<>("CS2103T"));
+    private static final List<JsonAdaptedProperty<Specialisation>> INVALID_SPECIALISATIONS = List.of(
+            new JsonAdaptedProperty<>(""));
+    private static final List<JsonAdaptedProperty<Specialisation>> CONTAINING_NULL_SPECIALISATIONS =
+            Stream.<JsonAdaptedProperty<Specialisation>>generate(() -> null)
+                    .limit(1).collect(Collectors.toCollection(ArrayList::new));
+    private static final List<JsonAdaptedProperty<Specialisation>> CONTAINING_DUPLICATE_SPECIALISATIONS = List.of(
+            new JsonAdaptedProperty<>("swe"), new JsonAdaptedProperty<>("swe"));
+    private static final List<JsonAdaptedProperty<Tag>> INVALID_TAGS =
+            List.of(new JsonAdaptedProperty<Tag>("#friend"));
+    private static final List<JsonAdaptedProperty<Tag>> CONTAINING_NULL_TAGS =
+            Stream.<JsonAdaptedProperty<Tag>>generate(() -> null)
+                    .limit(1).collect(Collectors.toCollection(ArrayList::new));
+    private static final List<JsonAdaptedProperty<Tag>> CONTAINING_DUPLICATE_TAGS = List.of(
+            new JsonAdaptedProperty<>("friend"), new JsonAdaptedProperty<>("friend"));
     private static final String INVALID_PRIORITY = "hi";
+    private static final String NULL_PRIORITY = null;
 
     private static final String VALID_NAME = TypicalPersons.BENSON.getName().toString();
     private static final List<JsonAdaptedProperty<Phone>> VALID_PHONES = TypicalPersons.BENSON.getPhones().stream()
@@ -56,13 +91,83 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedProperty<Course>> VALID_COURSES = TypicalPersons.BENSON.getCourses().stream()
             .map(JsonAdaptedProperty::new)
             .collect(Collectors.toList());
-    private static final List<JsonAdaptedProperty<Specialisation>> VALID_SPECIALISATION = List.of(
-            new JsonAdaptedProperty<Specialisation>("Game Development")
+    private static final List<JsonAdaptedProperty<Specialisation>> VALID_SPECIALISATIONS = List.of(
+            new JsonAdaptedProperty<>("Game Development")
     );
     private static final List<JsonAdaptedProperty<Tag>> VALID_TAGS = TypicalPersons.BENSON.getTags().stream()
             .map(JsonAdaptedProperty::new)
             .collect(Collectors.toList());
     private static final String VALID_PRIORITY = "mEDiUM";
+
+    @Test
+    public void assertFieldsAreNotNull_nullName_throwsNullValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(NULL_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        assertThrows(NullValueException.class, person::assertFieldsAreNotNull);
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_phonesContainNull_throwsNullValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, CONTAINING_NULL_PHONES, VALID_EMAILS,
+                VALID_LINKS, VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        assertThrows(NullValueException.class, person::assertFieldsAreNotNull);
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_emailsContainNull_throwsNullValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, CONTAINING_NULL_EMAILS,
+                VALID_LINKS, VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        assertThrows(NullValueException.class, person::assertFieldsAreNotNull);
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_linksContainNull_throwsNullValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,CONTAINING_NULL_LINKS,
+                VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        assertThrows(NullValueException.class, person::assertFieldsAreNotNull);
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_nullGraduation_throwsNothing() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                NULL_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        person.assertFieldsAreNotNull();
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_coursesContainNull_throwsNullValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                VALID_GRADUATION, CONTAINING_NULL_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        assertThrows(NullValueException.class, person::assertFieldsAreNotNull);
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_specialisationsContainNull_throwsNullValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                VALID_GRADUATION, VALID_COURSES, CONTAINING_NULL_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        assertThrows(NullValueException.class, person::assertFieldsAreNotNull);
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_tagsContainNull_throwsNullValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, CONTAINING_NULL_TAGS, VALID_PRIORITY);
+        assertThrows(NullValueException.class, person::assertFieldsAreNotNull);
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_nullPriority_throwsNothing() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, NULL_PRIORITY);
+        person.assertFieldsAreNotNull();
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_validFields_throwsNothing() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        person.assertFieldsAreNotNull();
+    }
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -75,16 +180,16 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONES, VALID_EMAILS,
                         VALID_LINKS, VALID_GRADUATION, VALID_COURSES,
-                        VALID_SPECIALISATION, VALID_TAGS, VALID_PRIORITY);
+                        VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONES, VALID_EMAILS,
+        JsonAdaptedPerson person = new JsonAdaptedPerson(NULL_NAME, VALID_PHONES, VALID_EMAILS,
                 VALID_LINKS, VALID_GRADUATION, VALID_COURSES,
-                VALID_SPECIALISATION, VALID_TAGS, VALID_PRIORITY);
+                VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = String.format(
                 JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT,
                 Name.class.getSimpleName()
@@ -93,13 +198,21 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
-    public void toModelType_invalidPhone_throwsIllegalValueException() {
+    public void toModelType_invalidPhones_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONES, VALID_EMAILS,
                         VALID_LINKS, VALID_GRADUATION, VALID_COURSES,
-                        VALID_SPECIALISATION, VALID_TAGS, VALID_PRIORITY);
+                        VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_duplicatePhones_throwsDuplicateEntryException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, CONTAINING_DUPLICATE_PHONES, VALID_EMAILS,
+                VALID_LINKS, VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        String expectedMessage = String.format(JsonAdaptedPerson.DUPLICATE_ENTRY_MESSAGE, "phone", "12345");
+        assertThrows(DuplicateEntryException.class, expectedMessage, person::toModelType);
     }
 
     @Test
@@ -107,9 +220,17 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, INVALID_EMAILS,
                         VALID_LINKS, VALID_GRADUATION, VALID_COURSES,
-                        VALID_SPECIALISATION, VALID_TAGS, VALID_PRIORITY);
+                        VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_duplicateEmails_throwsDuplicateEntryException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, CONTAINING_DUPLICATE_EMAILS,
+                VALID_LINKS, VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        String expectedMessage = String.format(JsonAdaptedPerson.DUPLICATE_ENTRY_MESSAGE, "email", "nkn@example.com");
+        assertThrows(DuplicateEntryException.class, expectedMessage, person::toModelType);
     }
 
     @Test
@@ -117,29 +238,55 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,
                         INVALID_LINKS, VALID_GRADUATION, VALID_COURSES,
-                        VALID_SPECIALISATION, VALID_TAGS, VALID_PRIORITY);
+                        VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Link.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
+    @Test
+    public void toModelType_duplicateLinks_throwsDuplicateEntryException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,
+                CONTAINING_DUPLICATE_LINKS, VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS,
+                VALID_TAGS, VALID_PRIORITY);
+        String expectedMessage = String.format(JsonAdaptedPerson.DUPLICATE_ENTRY_MESSAGE, "link", "example.com");
+        assertThrows(DuplicateEntryException.class, expectedMessage, person::toModelType);
+    }
 
     @Test
     public void toModelType_invalidGraduation_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,
                         VALID_LINKS, INVALID_GRADUATION, VALID_COURSES,
-                        VALID_SPECIALISATION, VALID_TAGS, VALID_PRIORITY);
+                        VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Graduation.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
+
+    @Test
+    public void toModelType_nullGraduation_success() throws Exception {
+        JsonAdaptedPerson jsonAdaptedPerson = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                NULL_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        PersonBuilder builder = new PersonBuilder(TypicalPersons.BENSON);
+        Person person = builder.withGraduation(null).withPriority("Medium").build();
+        assertEquals(person, jsonAdaptedPerson.toModelType());
+    }
+
     @Test
     public void toModelType_invalidCourse_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,
                         VALID_LINKS, VALID_GRADUATION, INVALID_COURSES,
-                        VALID_SPECIALISATION, VALID_TAGS, VALID_PRIORITY);
+                        VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Course.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_duplicateCourses_throwsDuplicateEntryException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                VALID_GRADUATION, CONTAINING_DUPLICATE_COURSES, VALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        String expectedMessage = String.format(JsonAdaptedPerson.DUPLICATE_ENTRY_MESSAGE, "course", "CS2103T");
+        assertThrows(DuplicateEntryException.class, person::toModelType);
     }
 
     @Test
@@ -147,41 +294,51 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,
                         VALID_LINKS, VALID_GRADUATION, VALID_COURSES,
-                        INVALID_SPECIALISATION, VALID_TAGS, VALID_PRIORITY);
+                        INVALID_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Specialisation.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_duplicateSpecialisations_throwsDuplicateEntryException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                VALID_GRADUATION, VALID_COURSES, CONTAINING_DUPLICATE_SPECIALISATIONS, VALID_TAGS, VALID_PRIORITY);
+        String expectedMessage = String.format(JsonAdaptedPerson.DUPLICATE_ENTRY_MESSAGE, "specialisation", "swe");
+        assertThrows(DuplicateEntryException.class, expectedMessage, person::toModelType);
     }
 
 
     @Test
     public void toModelType_invalidTags_throwsIllegalValueException() {
-        List<JsonAdaptedProperty<Tag>> invalidTags = new ArrayList<>(VALID_TAGS);
-        invalidTags.add(new JsonAdaptedProperty<>(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,
                         VALID_LINKS, VALID_GRADUATION, VALID_COURSES,
-                        VALID_SPECIALISATION, invalidTags, VALID_PRIORITY);
+                        VALID_SPECIALISATIONS, INVALID_TAGS, VALID_PRIORITY);
         assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_duplicateTags_throwsDuplicateEntryException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS, VALID_LINKS,
+                VALID_GRADUATION, VALID_COURSES, VALID_SPECIALISATIONS, CONTAINING_DUPLICATE_TAGS, VALID_PRIORITY);
+        String expectedMessage = String.format(JsonAdaptedPerson.DUPLICATE_ENTRY_MESSAGE, "tag", "friend");
+        assertThrows(DuplicateEntryException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidPriority_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,
                 VALID_LINKS, VALID_GRADUATION, VALID_COURSES,
-                VALID_SPECIALISATION, VALID_TAGS, INVALID_PRIORITY);
+                VALID_SPECIALISATIONS, VALID_TAGS, INVALID_PRIORITY);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
     @Test
-    public void toModelType_nullPriority_success() {
+    public void toModelType_nullPriority_success() throws Exception {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONES, VALID_EMAILS,
                 VALID_LINKS, VALID_GRADUATION, VALID_COURSES,
-                VALID_SPECIALISATION, VALID_TAGS, null);
-        try {
-            assertEquals(TypicalPersons.BENSON, person.toModelType());
-        } catch (IllegalValueException e) {
-            fail();
-        }
+                VALID_SPECIALISATIONS, VALID_TAGS, NULL_PRIORITY);
+        assertEquals(TypicalPersons.BENSON, person.toModelType());
     }
 
 }

--- a/src/test/java/networkbook/storage/JsonNetworkBookStorageTest.java
+++ b/src/test/java/networkbook/storage/JsonNetworkBookStorageTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.model.NetworkBook;
 import networkbook.model.ReadOnlyNetworkBook;
 import networkbook.testutil.TypicalPersons;
@@ -23,8 +24,10 @@ public class JsonNetworkBookStorageTest {
     public Path testFolder;
 
     @Test
-    public void readNetworkBook_nullFilePath_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> readNetworkBook(null));
+    public void readNetworkBook_nullFilePath_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> new JsonNetworkBookStorage(null).readNetworkBook());
+        assertThrows(AssertionError.class, ()
+                -> new JsonNetworkBookStorage(Paths.get("test.json")).readNetworkBook(null));
     }
 
     private java.util.Optional<ReadOnlyNetworkBook> readNetworkBook(String filePath) throws Exception {
@@ -55,6 +58,18 @@ public class JsonNetworkBookStorageTest {
     @Test
     public void readNetworkBook_invalidAndValidPersonNetworkBook_throwDataLoadingException() {
         assertThrows(DataLoadingException.class, () -> readNetworkBook("invalidAndValidPersonNetworkBook.json"));
+    }
+
+    @Test
+    public void readNetworkBook_networkBookWithOnePersonContainingDuplicatePhones_throwsDataLoadingException() {
+        assertThrows(DataLoadingException.class, () -> readNetworkBook(
+                "networkBookWithPersonContainingDuplicatePhones.json"));
+    }
+
+    @Test
+    public void readNetworkBook_networkBookWithPersonContainingNullPhone_throwsNullValueException() {
+        assertThrows(NullValueException.class, () -> readNetworkBook(
+                "networkBookWithPersonContainingNullPhone.json"));
     }
 
     @Test

--- a/src/test/java/networkbook/storage/JsonSerializableNetworkBookTest.java
+++ b/src/test/java/networkbook/storage/JsonSerializableNetworkBookTest.java
@@ -8,7 +8,9 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
+import networkbook.commons.exceptions.DuplicateEntryException;
 import networkbook.commons.exceptions.IllegalValueException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.JsonUtil;
 import networkbook.model.NetworkBook;
 import networkbook.testutil.TypicalPersons;
@@ -19,6 +21,10 @@ public class JsonSerializableNetworkBookTest {
     private static final Path TYPICAL_PERSONS_FILE = TEST_DATA_FOLDER.resolve("typicalPersonsNetworkBook.json");
     private static final Path INVALID_PERSON_FILE = TEST_DATA_FOLDER.resolve("invalidPersonNetworkBook.json");
     private static final Path DUPLICATE_PERSON_FILE = TEST_DATA_FOLDER.resolve("duplicatePersonNetworkBook.json");
+    private static final Path PERSON_WITH_DUPLICATE_PHONES_FILE =
+            TEST_DATA_FOLDER.resolve("personWithDuplicatePhones.json");
+    private static final Path PERSON_WITH_NULL_PHONE_FILE = TEST_DATA_FOLDER.resolve("personWithNullPhone.json");
+    private static final Path PERSON_WITH_NULL_NAME_FILE = TEST_DATA_FOLDER.resolve("personWithNullName.json");
 
     @Test
     public void toModelType_typicalPersonsFile_success() throws Exception {
@@ -44,4 +50,10 @@ public class JsonSerializableNetworkBookTest {
                 dataFromFile::toModelType);
     }
 
+    @Test
+    public void toModelType_personWithDuplicateFields_throwsDuplicateEntryException() throws Exception {
+        JsonSerializableNetworkBook dataFromFile = JsonUtil.readJsonFile(PERSON_WITH_DUPLICATE_PHONES_FILE,
+                JsonSerializableNetworkBook.class).get();
+        assertThrows(DuplicateEntryException.class, dataFromFile::toModelType);
+    }
 }

--- a/src/test/java/networkbook/storage/JsonSerializableNetworkBookTest.java
+++ b/src/test/java/networkbook/storage/JsonSerializableNetworkBookTest.java
@@ -5,11 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import networkbook.commons.exceptions.DuplicateEntryException;
 import networkbook.commons.exceptions.IllegalValueException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.JsonUtil;
 import networkbook.model.NetworkBook;
 import networkbook.testutil.TypicalPersons;
@@ -54,5 +57,26 @@ public class JsonSerializableNetworkBookTest {
         JsonSerializableNetworkBook dataFromFile = JsonUtil.readJsonFile(PERSON_WITH_DUPLICATE_PHONES_FILE,
                 JsonSerializableNetworkBook.class).get();
         assertThrows(DuplicateEntryException.class, dataFromFile::toModelType);
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_nullPerson_throwsNullValueException() {
+        List<JsonAdaptedPerson> personList = new ArrayList<>();
+        personList.add(null);
+        JsonSerializableNetworkBook networkBook = new JsonSerializableNetworkBook(personList);
+        assertThrows(NullValueException.class, networkBook::assertFieldsAreNotNull);
+    }
+
+    @Test
+    public void assertFieldsAreNotNull_personThrowingNullValueException_throwsNullValueException() {
+        JsonAdaptedPerson personThrowingNullValueException = new JsonAdaptedPerson(TypicalPersons.BENSON) {
+            public void assertFieldsAreNotNull() throws NullValueException {
+                throw new NullValueException();
+            }
+        };
+        List<JsonAdaptedPerson> personList = new ArrayList<>();
+        personList.add(personThrowingNullValueException);
+        JsonSerializableNetworkBook networkBook = new JsonSerializableNetworkBook(personList);
+        assertThrows(NullValueException.class, networkBook::assertFieldsAreNotNull);
     }
 }

--- a/src/test/java/networkbook/storage/JsonSerializableNetworkBookTest.java
+++ b/src/test/java/networkbook/storage/JsonSerializableNetworkBookTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import networkbook.commons.exceptions.DuplicateEntryException;
 import networkbook.commons.exceptions.IllegalValueException;
-import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.JsonUtil;
 import networkbook.model.NetworkBook;
 import networkbook.testutil.TypicalPersons;

--- a/src/test/java/networkbook/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/networkbook/storage/JsonUserPrefsStorageTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import networkbook.commons.core.GuiSettings;
 import networkbook.commons.exceptions.DataLoadingException;
+import networkbook.commons.exceptions.NullValueException;
 import networkbook.model.UserPrefs;
 
 public class JsonUserPrefsStorageTest {
@@ -68,6 +69,17 @@ public class JsonUserPrefsStorageTest {
         UserPrefs actual = readUserPrefs("ExtraValuesUserPref.json").get();
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void readUserPrefs_nullGuiSettings_throwsNullValueException() {
+        assertThrows(NullValueException.class, () -> readUserPrefs("nullGuiSettingsUserPrefs.json"));
+    }
+
+    @Test
+    public void readUserPrefs_nullNetworkBookFilePath_throwsNullValueException() {
+        assertThrows(NullValueException.class, ()
+                -> readUserPrefs("nullNetworkBookFilePathUserPrefs.json"));
     }
 
     private UserPrefs getTypicalUserPrefs() {

--- a/src/test/java/networkbook/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/networkbook/storage/JsonUserPrefsStorageTest.java
@@ -28,13 +28,13 @@ public class JsonUserPrefsStorageTest {
         assertThrows(NullPointerException.class, () -> readUserPrefs(null));
     }
 
-    private Optional<UserPrefs> readUserPrefs(String userPrefsFileInTestDataFolder) throws DataLoadingException {
+    private Optional<UserPrefs> readUserPrefs(String userPrefsFileInTestDataFolder) throws Exception {
         Path prefsFilePath = addToTestDataPathIfNotNull(userPrefsFileInTestDataFolder);
         return new JsonUserPrefsStorage(prefsFilePath).readUserPrefs(prefsFilePath);
     }
 
     @Test
-    public void readUserPrefs_missingFile_emptyResult() throws DataLoadingException {
+    public void readUserPrefs_missingFile_emptyResult() throws Exception {
         assertFalse(readUserPrefs("NonExistentFile.json").isPresent());
     }
 
@@ -50,20 +50,20 @@ public class JsonUserPrefsStorageTest {
     }
 
     @Test
-    public void readUserPrefs_fileInOrder_successfullyRead() throws DataLoadingException {
+    public void readUserPrefs_fileInOrder_successfullyRead() throws Exception {
         UserPrefs expected = getTypicalUserPrefs();
         UserPrefs actual = readUserPrefs("TypicalUserPref.json").get();
         assertEquals(expected, actual);
     }
 
     @Test
-    public void readUserPrefs_valuesMissingFromFile_defaultValuesUsed() throws DataLoadingException {
+    public void readUserPrefs_valuesMissingFromFile_defaultValuesUsed() throws Exception {
         UserPrefs actual = readUserPrefs("EmptyUserPrefs.json").get();
         assertEquals(new UserPrefs(), actual);
     }
 
     @Test
-    public void readUserPrefs_extraValuesInFile_extraValuesIgnored() throws DataLoadingException {
+    public void readUserPrefs_extraValuesInFile_extraValuesIgnored() throws Exception {
         UserPrefs expected = getTypicalUserPrefs();
         UserPrefs actual = readUserPrefs("ExtraValuesUserPref.json").get();
 
@@ -100,7 +100,7 @@ public class JsonUserPrefsStorageTest {
     }
 
     @Test
-    public void saveUserPrefs_allInOrder_success() throws DataLoadingException, IOException {
+    public void saveUserPrefs_allInOrder_success() throws Exception {
 
         UserPrefs original = new UserPrefs();
         original.setGuiSettings(new GuiSettings(1200, 200, 0, 2));

--- a/src/test/java/networkbook/testutil/PersonBuilder.java
+++ b/src/test/java/networkbook/testutil/PersonBuilder.java
@@ -107,7 +107,11 @@ public class PersonBuilder {
      * Sets the {@code Graduation} of the {@code Person} that we are building.
      */
     public PersonBuilder withGraduation(String graduation) {
-        this.graduation = new Graduation(graduation);
+        if (graduation != null) {
+            this.graduation = new Graduation(graduation);
+        } else {
+            this.graduation = null;
+        }
         return this;
     }
 
@@ -194,7 +198,11 @@ public class PersonBuilder {
      * Sets the {@code Priority} of the {@code Person} that we are building.
      */
     public PersonBuilder withPriority(String priority) {
-        this.priority = new Priority(priority);
+        if (priority != null) {
+            this.priority = new Priority(priority);
+        } else {
+            this.priority = null;
+        }
         return this;
     }
 

--- a/src/test/java/networkbook/testutil/SerializableTestClass.java
+++ b/src/test/java/networkbook/testutil/SerializableTestClass.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import networkbook.commons.exceptions.NullValueException;
 import networkbook.commons.util.JsonObject;
 
 /**

--- a/src/test/java/networkbook/testutil/SerializableTestClass.java
+++ b/src/test/java/networkbook/testutil/SerializableTestClass.java
@@ -5,10 +5,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import networkbook.commons.exceptions.NullValueException;
+import networkbook.commons.util.JsonObject;
+
 /**
  * A class used to test serialization and deserialization
  */
-public class SerializableTestClass {
+public class SerializableTestClass implements JsonObject {
     public static final String JSON_STRING_REPRESENTATION = String.format("{%n"
             + "  \"name\" : \"This is a test class\",%n"
             + "  \"listOfLocalDateTimes\" : "
@@ -68,5 +71,8 @@ public class SerializableTestClass {
 
     public HashMap<Integer, String> getMapOfIntegerToString() {
         return mapOfIntegerToString;
+    }
+
+    public void assertFieldsAreNotNull() {
     }
 }


### PR DESCRIPTION
* If any value is `null`, the programme resorts to default values.
* If there are duplicates in a unique list, the programme resorts to an empty model.
* Email regex is fixed to fit the description in the user guide.