### PR TITLE
Fix log file readonly bug

### DIFF
--- a/src/main/java/networkbook/commons/core/LogsCenter.java
+++ b/src/main/java/networkbook/commons/core/LogsCenter.java
@@ -92,13 +92,18 @@ public class LogsCenter {
         baseLogger.addHandler(consoleHandler);
 
         // add a FileHandler to log to a file
-        try {
-            FileHandler fileHandler = new FileHandler(LOG_FILE, MAX_FILE_SIZE_IN_BYTES, MAX_FILE_COUNT, true);
-            fileHandler.setFormatter(new SimpleFormatter());
-            fileHandler.setLevel(Level.ALL);
-            baseLogger.addHandler(fileHandler);
-        } catch (IOException e) {
-            logger.warning("Error adding file handler for logger.");
+        String filename = LOG_FILE;
+        boolean isLogFileCreated = false;
+        while (!isLogFileCreated) {
+            try {
+                FileHandler fileHandler = new FileHandler(filename, MAX_FILE_SIZE_IN_BYTES, MAX_FILE_COUNT, true);
+                fileHandler.setFormatter(new SimpleFormatter());
+                fileHandler.setLevel(Level.ALL);
+                baseLogger.addHandler(fileHandler);
+                isLogFileCreated = true;
+            } catch (IOException e) {
+                filename += ".1";
+            }
         }
     }
 

--- a/src/main/java/networkbook/commons/core/LogsCenter.java
+++ b/src/main/java/networkbook/commons/core/LogsCenter.java
@@ -92,18 +92,13 @@ public class LogsCenter {
         baseLogger.addHandler(consoleHandler);
 
         // add a FileHandler to log to a file
-        String filename = LOG_FILE;
-        boolean isLogFileCreated = false;
-        while (!isLogFileCreated) {
-            try {
-                FileHandler fileHandler = new FileHandler(filename, MAX_FILE_SIZE_IN_BYTES, MAX_FILE_COUNT, true);
-                fileHandler.setFormatter(new SimpleFormatter());
-                fileHandler.setLevel(Level.ALL);
-                baseLogger.addHandler(fileHandler);
-                isLogFileCreated = true;
-            } catch (IOException e) {
-                filename += ".1";
-            }
+        try {
+            FileHandler fileHandler = new FileHandler(LOG_FILE, MAX_FILE_SIZE_IN_BYTES, MAX_FILE_COUNT, true);
+            fileHandler.setFormatter(new SimpleFormatter());
+            fileHandler.setLevel(Level.ALL);
+            baseLogger.addHandler(fileHandler);
+        } catch (IOException e) {
+            baseLogger.warning("Cannot create file handler for logger.");
         }
     }
 


### PR DESCRIPTION
If log file does not have write permission, create a new log file with a different name.