### PR TITLE
Fix displayed list reverting bug

### DIFF
--- a/src/main/java/networkbook/model/NetworkBook.java
+++ b/src/main/java/networkbook/model/NetworkBook.java
@@ -1,6 +1,7 @@
 package networkbook.model;
 
 import static java.util.Objects.requireNonNull;
+import static networkbook.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -34,6 +35,7 @@ public class NetworkBook implements ReadOnlyNetworkBook {
     public NetworkBook() {
         persons = new UniqueList<>();
         filteredPersons = new FilteredList<>(persons.asUnmodifiableObservableList());
+        setFilterPredicate(PREDICATE_SHOW_ALL_PERSONS);
         displayedPersons = new SortedList<>(filteredPersons,
                 new PersonSortComparator(PersonSortComparator.SortField.NAME,
                                         PersonSortComparator.SortOrder.ASCENDING));

--- a/src/main/java/networkbook/model/NetworkBook.java
+++ b/src/main/java/networkbook/model/NetworkBook.java
@@ -35,7 +35,7 @@ public class NetworkBook implements ReadOnlyNetworkBook {
     public NetworkBook() {
         persons = new UniqueList<>();
         filteredPersons = new FilteredList<>(persons.asUnmodifiableObservableList());
-        setFilterPredicate(PREDICATE_SHOW_ALL_PERSONS);
+        filteredPersons.setPredicate(PREDICATE_SHOW_ALL_PERSONS);
         displayedPersons = new SortedList<>(filteredPersons,
                 new PersonSortComparator(PersonSortComparator.SortField.NAME,
                                         PersonSortComparator.SortOrder.ASCENDING));

--- a/src/test/java/networkbook/model/VersionedNetworkBookTest.java
+++ b/src/test/java/networkbook/model/VersionedNetworkBookTest.java
@@ -7,9 +7,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import networkbook.model.person.NameContainsKeyTermsPredicate;
 import networkbook.testutil.TypicalPersons;
 
 public class VersionedNetworkBookTest {
@@ -54,7 +56,7 @@ public class VersionedNetworkBookTest {
     }
 
     @Test
-    public void undo() {
+    public void undo_changeData() {
         VersionedNetworkBook versionedNetworkBook = new VersionedNetworkBook();
         versionedNetworkBook.addPerson(TypicalPersons.ALICE);
         versionedNetworkBook.commit();
@@ -71,7 +73,29 @@ public class VersionedNetworkBookTest {
     }
 
     @Test
-    public void redo() {
+    public void undo_changeDisplay() {
+        VersionedNetworkBook versionedNetworkBook = new VersionedNetworkBook();
+        versionedNetworkBook.addPerson(TypicalPersons.ALICE);
+        versionedNetworkBook.addPerson(TypicalPersons.BENSON);
+        versionedNetworkBook.commit();
+        NameContainsKeyTermsPredicate predicate = new NameContainsKeyTermsPredicate(List.of("Alice"));
+        versionedNetworkBook.setFilterPredicate(predicate);
+        versionedNetworkBook.commit();
+        NetworkBook expected = new NetworkBook();
+        expected.addPerson(TypicalPersons.ALICE);
+        assertEquals(expected.getDisplayedPersonList(), versionedNetworkBook.getDisplayedPersonList());
+        versionedNetworkBook.undo();
+        assertEquals(1, versionedNetworkBook.getCurrentStatePointer());
+        expected.addPerson(TypicalPersons.BENSON);
+        assertEquals(expected.getDisplayedPersonList(), versionedNetworkBook.getDisplayedPersonList());
+        versionedNetworkBook.undo();
+        expected.removePerson(TypicalPersons.ALICE);
+        expected.removePerson(TypicalPersons.BENSON);
+        assertEquals(expected.getDisplayedPersonList(), versionedNetworkBook.getDisplayedPersonList());
+    }
+
+    @Test
+    public void redo_changeData() {
         VersionedNetworkBook versionedNetworkBook = new VersionedNetworkBook();
         versionedNetworkBook.addPerson(TypicalPersons.ALICE);
         versionedNetworkBook.commit();
@@ -89,6 +113,26 @@ public class VersionedNetworkBookTest {
         expected.addPerson(TypicalPersons.BENSON);
         assertEquals(2, versionedNetworkBook.getCurrentStatePointer());
         assertEquals(expected.getPersonList(), versionedNetworkBook.getPersonList());
+    }
+
+    @Test
+    public void redo_changeDisplay() {
+        VersionedNetworkBook versionedNetworkBook = new VersionedNetworkBook();
+        versionedNetworkBook.addPerson(TypicalPersons.ALICE);
+        versionedNetworkBook.addPerson(TypicalPersons.BENSON);
+        versionedNetworkBook.commit();
+        NameContainsKeyTermsPredicate predicate = new NameContainsKeyTermsPredicate(List.of("Alice"));
+        versionedNetworkBook.setFilterPredicate(predicate);
+        versionedNetworkBook.commit();
+        NetworkBook expected = new NetworkBook();
+        expected.addPerson(TypicalPersons.ALICE);
+        assertEquals(expected.getDisplayedPersonList(), versionedNetworkBook.getDisplayedPersonList());
+        versionedNetworkBook.undo();
+        expected.addPerson(TypicalPersons.BENSON);
+        assertEquals(expected.getDisplayedPersonList(), versionedNetworkBook.getDisplayedPersonList());
+        versionedNetworkBook.redo();
+        expected.removePerson(TypicalPersons.BENSON);
+        assertEquals(expected.getDisplayedPersonList(), versionedNetworkBook.getDisplayedPersonList());
     }
 
     @Test


### PR DESCRIPTION
Display list history loading doesn't work because filter predicate was null in a newly initialised NetworkBook. Remedied.

Fixes #184 