### PR TITLE
Remove misleading message of index where contact is created

### DIFF
--- a/src/main/java/networkbook/logic/commands/CreateCommand.java
+++ b/src/main/java/networkbook/logic/commands/CreateCommand.java
@@ -59,8 +59,7 @@ public class CreateCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd))
-            + String.format(MESSAGE_SUCCESS_INDEX, model.getDisplayedPersonList().size()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 
     @Override

--- a/src/main/java/networkbook/logic/commands/CreateCommand.java
+++ b/src/main/java/networkbook/logic/commands/CreateCommand.java
@@ -35,7 +35,6 @@ public class CreateCommand extends Command {
             + CliSyntax.PREFIX_TAG + " owesMoney";
 
     public static final String MESSAGE_SUCCESS = "Noted, created new contact: \n%1$s";
-    public static final String MESSAGE_SUCCESS_INDEX = "\nAt index %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This contact already exists in the network book";
 
     private final Person toAdd;

--- a/src/test/java/networkbook/logic/commands/CreateCommandIntegrationTest.java
+++ b/src/test/java/networkbook/logic/commands/CreateCommandIntegrationTest.java
@@ -31,8 +31,7 @@ public class CreateCommandIntegrationTest {
         expectedModel.addPerson(validPerson);
 
         CommandTestUtil.assertCommandSuccess(new CreateCommand(validPerson), model,
-                String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson))
-                    + String.format(CreateCommand.MESSAGE_SUCCESS_INDEX, expectedModel.getDisplayedPersonList().size()),
+                String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
                 expectedModel);
     }
 

--- a/src/test/java/networkbook/logic/commands/CreateCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/CreateCommandTest.java
@@ -44,8 +44,7 @@ public class CreateCommandTest {
 
         CommandResult commandResult = new CreateCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson))
-                        + "\nAt index 1",
+        assertEquals(String.format(CreateCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }


### PR DESCRIPTION
After contact creation, contact is said to be created at end of the list which is erroneous. Message has been altered to take away that part. 

Fixes #187 