### PR TITLE
Fix link regex invalidation issue

### DIFF
--- a/src/main/java/networkbook/model/person/Link.java
+++ b/src/main/java/networkbook/model/person/Link.java
@@ -28,11 +28,16 @@ public class Link implements Identifiable<Link> {
     //          /valid-characters-for-directory-part-of-a-url-for-short-links
     private static final String PATH_REGEX = "(/[a-zA-Z0-9_\\-.~!$&'()*+,;=:@]*)*"; // Valid URI path
 
-    // regex reused from https://stackoverflow.com/questions/23959352/validate-url-query-string-with-regex
-    private static final String QUERY_REGEX = "\\?([\\w-]+(=[\\w-]*)?(&[\\w-]+(=[\\w-]*)?)*)?";
+    // regex adapted from https://stackoverflow.com/questions/23959352/validate-url-query-string-with-regex
+    private static final String QUERY_ALLOWED_CHARS = "[\\w-_.~+%]";
+    private static final String QUERY_REGEX = "\\?(" + QUERY_ALLOWED_CHARS
+            + "+(=" + QUERY_ALLOWED_CHARS + "*)?(&" + QUERY_ALLOWED_CHARS
+            + "+(=" + QUERY_ALLOWED_CHARS + "*)?)*)?";
 
-    public static final String VALIDATION_REGEX = DOMAIN_NAME_REGEX
-            + "(" + PATH_REGEX + ")?" + "(" + QUERY_REGEX + ")?$";
+    private static final String HASH_REGEX = "#.*";
+
+    private static final String VALIDATION_REGEX = DOMAIN_NAME_REGEX
+            + "(" + PATH_REGEX + ")?" + "(" + QUERY_REGEX + ")?" + "(" + HASH_REGEX + ")?$";
 
     private final String value;
 

--- a/src/test/java/networkbook/model/person/LinkTest.java
+++ b/src/test/java/networkbook/model/person/LinkTest.java
@@ -22,10 +22,10 @@ public class LinkTest {
 
     @Test
     public void isValidLink() {
-        // null email
+        // null link
         assertThrows(NullPointerException.class, () -> Link.isValidLink(null));
 
-        // blank email
+        // blank link
         assertFalse(Link.isValidLink("")); // empty string
         assertFalse(Link.isValidLink(" ")); // spaces only
 
@@ -37,6 +37,10 @@ public class LinkTest {
         // invalid parts
         assertFalse(Link.isValidLink("peterjack@-.com")); // invalid domain name
         assertFalse(Link.isValidLink("exam_ple.com")); // underscore in domain name
+
+        // hash
+        assertFalse(Link.isValidLink("google#test.com")); // incomplete domain label, hash appears too early
+        assertFalse(Link.isValidLink("google.com/search?q=test#\n")); // should not have any new line char
 
         // valid link
         assertTrue(Link.isValidLink("pythonanywhere.com/user/test"));
@@ -52,6 +56,10 @@ public class LinkTest {
         assertTrue(Link.isValidLink("https://www.google.com/?q=haha"));
         assertTrue(Link.isValidLink("https://www.google.com?q=haha"));
         assertTrue(Link.isValidLink("https://www.google.com/ncr?q=haha"));
+        assertTrue(Link.isValidLink("google.com/test#test")); // accommodate for hash
+        assertTrue(Link.isValidLink("google.com/test?#test")); // fine to have empty query params
+        assertTrue(Link.isValidLink("google.com#test")); // empty query params and pathname
+        assertTrue(Link.isValidLink("google.com#~!@#$%^&*()?/<>,.")); // any char except \n after # is fine
     }
 
     @Test


### PR DESCRIPTION
Hash, `#`, was not previously allowed. Now,
* Hash is allowed.
* Any char is allowed beyond hash except new line chars.
* Hash should not appear when domain is incomplete (i.e. at least one period `.` must be present before the hash)