### PR TITLE
Fix shortcut not working issue on macOS

### DIFF
--- a/src/main/java/networkbook/ui/CommandBox.java
+++ b/src/main/java/networkbook/ui/CommandBox.java
@@ -30,15 +30,15 @@ public class CommandBox extends UiPart<Region> {
 
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
-    private static final KeyCombination SHORTCUT_FIND =
+    private static final KeyCharacterCombination SHORTCUT_FIND =
             new KeyCharacterCombination("F", KeyCombination.SHORTCUT_DOWN);
-    private static final KeyCombination SHORTCUT_CREATE =
+    private static final KeyCharacterCombination SHORTCUT_CREATE =
             new KeyCharacterCombination("N", KeyCombination.SHORTCUT_DOWN);
-    private static final KeyCombination SHORTCUT_EDIT =
+    private static final KeyCharacterCombination SHORTCUT_EDIT =
             new KeyCharacterCombination("G", KeyCombination.SHORTCUT_DOWN);
-    private static final KeyCombination SHORTCUT_UNDO =
+    private static final KeyCharacterCombination SHORTCUT_UNDO =
             new KeyCharacterCombination("U", KeyCombination.SHORTCUT_DOWN);
-    private static final KeyCombination SHORTCUT_REDO =
+    private static final KeyCharacterCombination SHORTCUT_REDO =
             new KeyCharacterCombination("R", KeyCombination.SHORTCUT_DOWN);
     private static final KeyCode SHORTCUT_UP = KeyCode.UP;
     private static final KeyCode SHORTCUT_DOWN = KeyCode.DOWN;
@@ -68,19 +68,20 @@ public class CommandBox extends UiPart<Region> {
         commandTextField.setOnKeyPressed(new EventHandler<KeyEvent>() {
             @Override
             public void handle(KeyEvent event) {
-                if (SHORTCUT_FIND.match(event)) {
+                if (KeyboardShortcutUtil.shortcutMatchEvent(SHORTCUT_FIND, event)) {
+                    System.out.println("find shortcut executed");
                     autoFillCommandIfEmpty(FindCommand.COMMAND_WORD + WHITESPACE);
                     event.consume();
-                } else if (SHORTCUT_CREATE.match(event)) {
+                } else if (KeyboardShortcutUtil.shortcutMatchEvent(SHORTCUT_CREATE, event)) {
                     autoFillCommandIfEmpty(CreateCommand.COMMAND_WORD + WHITESPACE);
                     event.consume();
-                } else if (SHORTCUT_EDIT.match(event)) {
+                } else if (KeyboardShortcutUtil.shortcutMatchEvent(SHORTCUT_EDIT, event)) {
                     autoFillCommandIfEmpty(EditCommand.COMMAND_WORD + WHITESPACE);
                     event.consume();
-                } else if (SHORTCUT_UNDO.match(event)) {
+                } else if (KeyboardShortcutUtil.shortcutMatchEvent(SHORTCUT_UNDO, event)) {
                     autoFillCommandIfEmpty(UndoCommand.COMMAND_WORD);
                     event.consume();
-                } else if (SHORTCUT_REDO.match(event)) {
+                } else if (KeyboardShortcutUtil.shortcutMatchEvent(SHORTCUT_REDO, event)) {
                     autoFillCommandIfEmpty(RedoCommand.COMMAND_WORD);
                     event.consume();
                 } else if (noModifier(event) && event.getCode() == SHORTCUT_UP) {

--- a/src/main/java/networkbook/ui/KeyboardShortcutUtil.java
+++ b/src/main/java/networkbook/ui/KeyboardShortcutUtil.java
@@ -1,0 +1,36 @@
+package networkbook.ui;
+
+import javafx.scene.input.KeyCharacterCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
+
+/**
+ * Utility class containing useful shared functions related to keyboard shortcuts.
+ */
+public class KeyboardShortcutUtil {
+
+    /**
+     * Checks if a shortcut represented by a {@code KeyCharacterCombination} matches a keyboard input event.
+     * This is used when the default KeyCombination#match does not work properly on macOS.
+     * @param combination is the shortcut.
+     * @param event is the new {@code KeyEvent} to be checked with.
+     * @return boolean result of the match.
+     */
+    public static boolean shortcutMatchEvent(KeyCharacterCombination combination, KeyEvent event) {
+        boolean result = event.getCode().getChar().equals(combination.getCharacter());
+        if (!combination.getShortcut().equals(KeyCombination.ModifierValue.ANY)) {
+            result = result && event.isShortcutDown()
+                    == combination.getShortcut().equals(KeyCombination.ModifierValue.DOWN);
+        }
+        if (!combination.getShift().equals(KeyCombination.ModifierValue.ANY)) {
+            result = result && event.isShiftDown()
+                    == combination.getShift().equals(KeyCombination.ModifierValue.DOWN);
+        }
+        if (!combination.getAlt().equals(KeyCombination.ModifierValue.ANY)) {
+            result = result && event.isAltDown()
+                    == combination.getAlt().equals(KeyCombination.ModifierValue.DOWN);
+        }
+        return result;
+    }
+}
+

--- a/src/main/java/networkbook/ui/MainWindow.java
+++ b/src/main/java/networkbook/ui/MainWindow.java
@@ -36,13 +36,13 @@ public class MainWindow extends UiPart<Stage> {
 
     private static final String FXML = "MainWindow.fxml";
     private static final KeyCombination SHORTCUT_HELP = KeyCombination.valueOf("F1");
-    private static final KeyCombination SHORTCUT_EXIT =
+    private static final KeyCharacterCombination SHORTCUT_EXIT =
             new KeyCharacterCombination("W", KeyCombination.SHORTCUT_DOWN);
-    private static final KeyCombination SHORTCUT_UNDO_UNFOCUSED =
+    private static final KeyCharacterCombination SHORTCUT_UNDO_UNFOCUSED =
             new KeyCharacterCombination("Z", KeyCombination.SHORTCUT_DOWN);
-    private static final KeyCombination SHORTCUT_REDO_UNFOCUSED =
+    private static final KeyCharacterCombination SHORTCUT_REDO_UNFOCUSED =
             new KeyCharacterCombination("Y", KeyCombination.SHORTCUT_DOWN);
-    private static final KeyCombination SHORTCUT_SAVE =
+    private static final KeyCharacterCombination SHORTCUT_SAVE =
             new KeyCharacterCombination("S", KeyCombination.SHORTCUT_DOWN);
     private final Logger logger = LogsCenter.getLogger(getClass());
 
@@ -98,7 +98,13 @@ public class MainWindow extends UiPart<Stage> {
 
     private void setAccelerators() {
         setAccelerator(helpMenuItem, SHORTCUT_HELP);
-        setAccelerator(exitMenuItem, SHORTCUT_EXIT);
+        exitMenuItem.setAccelerator(SHORTCUT_EXIT);
+        getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (KeyboardShortcutUtil.shortcutMatchEvent(SHORTCUT_EXIT, event)) {
+                exitMenuItem.getOnAction().handle(new ActionEvent());
+                event.consume();
+            }
+        });
     }
 
     /**
@@ -151,13 +157,15 @@ public class MainWindow extends UiPart<Stage> {
 
     private void setCommandBoxShortcutsWhenUnfocused(CommandBox commandBox) {
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            if (!commandBox.isTextFieldFocused() && SHORTCUT_UNDO_UNFOCUSED.match(event)) {
+            if (!commandBox.isTextFieldFocused()
+                    && KeyboardShortcutUtil.shortcutMatchEvent(SHORTCUT_UNDO_UNFOCUSED, event)) {
                 injectCommand(UndoCommand.COMMAND_WORD);
                 event.consume();
-            } else if (!commandBox.isTextFieldFocused() && SHORTCUT_REDO_UNFOCUSED.match(event)) {
+            } else if (!commandBox.isTextFieldFocused()
+                    && KeyboardShortcutUtil.shortcutMatchEvent(SHORTCUT_REDO_UNFOCUSED, event)) {
                 injectCommand(RedoCommand.COMMAND_WORD);
                 event.consume();
-            } else if (SHORTCUT_SAVE.match(event)) {
+            } else if (KeyboardShortcutUtil.shortcutMatchEvent(SHORTCUT_SAVE, event)) {
                 injectCommand(SaveCommand.COMMAND_WORD);
                 event.consume();
             }

--- a/src/test/java/networkbook/ui/KeyboardShortcutUtilTest.java
+++ b/src/test/java/networkbook/ui/KeyboardShortcutUtilTest.java
@@ -16,10 +16,16 @@ public class KeyboardShortcutUtilTest {
     private static final KeyCharacterCombination combiF = new KeyCharacterCombination("F");
     private static final KeyCharacterCombination combiShortcutF = new KeyCharacterCombination("F",
             KeyCombination.SHORTCUT_DOWN);
+    private static final KeyCharacterCombination combiShortcutAnyF = new KeyCharacterCombination("F",
+            KeyCombination.SHORTCUT_ANY);
     private static final KeyCharacterCombination combiShiftF = new KeyCharacterCombination("F",
             KeyCombination.SHIFT_DOWN);
+    private static final KeyCharacterCombination combiShiftAnyF = new KeyCharacterCombination("F",
+            KeyCombination.SHIFT_ANY);
     private static final KeyCharacterCombination combiAltF = new KeyCharacterCombination("F",
             KeyCombination.ALT_DOWN);
+    private static final KeyCharacterCombination combiAltAnyF = new KeyCharacterCombination("F",
+            KeyCombination.ALT_ANY);
 
     private static final KeyEvent eventF = new KeyEvent(KeyEvent.KEY_PRESSED,
             "f", "f", KeyCode.F, false, false, false, false);
@@ -42,6 +48,13 @@ public class KeyboardShortcutUtilTest {
         assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutF, eventShortcutF));
         assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftF, eventShiftF));
         assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiAltF, eventAltF));
+
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutAnyF, eventF));
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutAnyF, eventShortcutF));
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftAnyF, eventF));
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftAnyF, eventShiftF));
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiAltAnyF, eventF));
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiAltAnyF, eventAltF));
     }
 
     @Test
@@ -55,10 +68,25 @@ public class KeyboardShortcutUtilTest {
         assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiF, eventShortcutF));
         assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiF, eventShiftF));
         assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiF, eventAltF));
+
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftF, eventShortcutF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiAltF, eventShortcutF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftAnyF, eventShortcutF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiAltAnyF, eventShortcutF));
+
         assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutF, eventShiftF));
         assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiAltF, eventShiftF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutAnyF, eventShiftF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiAltAnyF, eventShiftF));
+
         assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutF, eventAltF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftF, eventAltF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutAnyF, eventAltF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftAnyF, eventAltF));
+
         assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftF, eventShiftAltF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftAnyF, eventShiftAltF));
         assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiAltF, eventShiftAltF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiAltAnyF, eventShiftAltF));
     }
 }

--- a/src/test/java/networkbook/ui/KeyboardShortcutUtilTest.java
+++ b/src/test/java/networkbook/ui/KeyboardShortcutUtilTest.java
@@ -1,0 +1,64 @@
+package networkbook.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.scene.input.KeyCharacterCombination;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
+
+
+
+public class KeyboardShortcutUtilTest {
+    private static final KeyCharacterCombination combiF = new KeyCharacterCombination("F");
+    private static final KeyCharacterCombination combiShortcutF = new KeyCharacterCombination("F",
+            KeyCombination.SHORTCUT_DOWN);
+    private static final KeyCharacterCombination combiShiftF = new KeyCharacterCombination("F",
+            KeyCombination.SHIFT_DOWN);
+    private static final KeyCharacterCombination combiAltF = new KeyCharacterCombination("F",
+            KeyCombination.ALT_DOWN);
+
+    private static final KeyEvent eventF = new KeyEvent(KeyEvent.KEY_PRESSED,
+            "f", "f", KeyCode.F, false, false, false, false);
+    private static final KeyEvent eventN = new KeyEvent(KeyEvent.KEY_PRESSED,
+            "n", "n", KeyCode.N, false, false, false, false);
+    private static final KeyEvent eventShortcutF = new KeyEvent(KeyEvent.KEY_PRESSED,
+            "f", "f", KeyCode.F, false, true, false, true);
+    private static final KeyEvent eventShortcutN = new KeyEvent(KeyEvent.KEY_PRESSED,
+            "n", "n", KeyCode.N, false, true, false, true);
+    private static final KeyEvent eventShiftF = new KeyEvent(KeyEvent.KEY_PRESSED,
+            "f", "f", KeyCode.F, true, false, false, false);
+    private static final KeyEvent eventAltF = new KeyEvent(KeyEvent.KEY_PRESSED,
+            "f", "f", KeyCode.F, false, false, true, false);
+    private static final KeyEvent eventShiftAltF = new KeyEvent(KeyEvent.KEY_PRESSED,
+            "f", "f", KeyCode.F, true, false, true, false);
+
+    @Test
+    public void shortcutMatchEvent_match_true() {
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiF, eventF));
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutF, eventShortcutF));
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftF, eventShiftF));
+        assertTrue(KeyboardShortcutUtil.shortcutMatchEvent(combiAltF, eventAltF));
+    }
+
+    @Test
+    public void shortcutMatchEvent_codeDoesNotMatch_false() {
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiF, eventN));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutF, eventShortcutN));
+    }
+
+    @Test
+    public void shortcutMatchEvent_modifierDoesNotMatch_false() {
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiF, eventShortcutF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiF, eventShiftF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiF, eventAltF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutF, eventShiftF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiAltF, eventShiftF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShortcutF, eventAltF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiShiftF, eventShiftAltF));
+        assertFalse(KeyboardShortcutUtil.shortcutMatchEvent(combiAltF, eventShiftAltF));
+    }
+}


### PR DESCRIPTION
The issue was cause by KeyCombination#match not working properly on macOS.
Before, this method only works after the character has been typed once.
e.g. ctrl-F can only be matched after the upper-case 'F' has been typed.
Could not find online bug reports of this issue, probably javafx version specific.

Solved issue with self-created method to manually check if the shortcut matches.
Closes #209. 