### PR TITLE
Remove test cases with multiple invalid inputs

### DIFF
--- a/src/test/java/networkbook/logic/commands/OpenLinkCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/OpenLinkCommandTest.java
@@ -124,7 +124,6 @@ public class OpenLinkCommandTest {
 
     @Test
     public void constructor_null_throwsAssertionError() {
-        assertThrowsAssertionError(() -> new OpenLinkCommand(null, null));
         assertThrowsAssertionError(() -> new OpenLinkCommand(TypicalIndexes.INDEX_FIRST_PERSON, null));
         assertThrowsAssertionError(() -> new OpenLinkCommand(null, CommandTestUtil.VALID_LINK_INDEX_AMY));
     }

--- a/src/test/java/networkbook/logic/commands/delete/DeleteFieldCommandTest.java
+++ b/src/test/java/networkbook/logic/commands/delete/DeleteFieldCommandTest.java
@@ -47,7 +47,6 @@ public class DeleteFieldCommandTest {
     public void constructor_null_nullPointerException() {
         assertThrowsAssertionError(() -> new DeleteFieldCommand(null, DELETE_PRIORITY_ACTION));
         assertThrowsAssertionError(() -> new DeleteFieldCommand(INDEX_ONE, null));
-        assertThrowsAssertionError(() -> new DeleteFieldCommand(null, null));
     }
 
     @Test

--- a/src/test/java/networkbook/logic/commands/edit/EditPersonDescriptorTest.java
+++ b/src/test/java/networkbook/logic/commands/edit/EditPersonDescriptorTest.java
@@ -79,8 +79,6 @@ public class EditPersonDescriptorTest {
                 TypicalIndexes.INDEX_FIRST_PERSON));
         assertThrowsAssertionError(() -> actualDescriptor.setPhone(EditCommandUtil.VALID_INDEX, null,
                 TypicalIndexes.INDEX_FIRST_PERSON));
-        assertThrowsAssertionError(() -> actualDescriptor.setPhone(null, null,
-                TypicalIndexes.INDEX_FIRST_PERSON));
     }
 
     @Test
@@ -131,8 +129,6 @@ public class EditPersonDescriptorTest {
                 TypicalIndexes.INDEX_FIRST_PERSON));
         assertThrowsAssertionError(() -> actualDescriptor.setEmail(EditCommandUtil.VALID_INDEX, null,
                 TypicalIndexes.INDEX_FIRST_PERSON));
-        assertThrowsAssertionError(() -> actualDescriptor.setEmail(null, null,
-                TypicalIndexes.INDEX_FIRST_PERSON));
     }
 
     @Test
@@ -182,8 +178,6 @@ public class EditPersonDescriptorTest {
         assertThrowsAssertionError(() -> actualDescriptor.setLink(null, EditCommandUtil.VALID_LINK,
                 TypicalIndexes.INDEX_FIRST_PERSON));
         assertThrowsAssertionError(() -> actualDescriptor.setLink(EditCommandUtil.VALID_INDEX, null,
-                TypicalIndexes.INDEX_FIRST_PERSON));
-        assertThrowsAssertionError(() -> actualDescriptor.setLink(null, null,
                 TypicalIndexes.INDEX_FIRST_PERSON));
     }
 
@@ -261,8 +255,6 @@ public class EditPersonDescriptorTest {
                 TypicalIndexes.INDEX_FIRST_PERSON));
         assertThrowsAssertionError(() -> actualDescriptor.setCourse(EditCommandUtil.VALID_INDEX, null,
                 TypicalIndexes.INDEX_FIRST_PERSON));
-        assertThrowsAssertionError(() -> actualDescriptor.setCourse(null, null,
-                TypicalIndexes.INDEX_FIRST_PERSON));
     }
 
     @Test
@@ -314,8 +306,6 @@ public class EditPersonDescriptorTest {
                 TypicalIndexes.INDEX_FIRST_PERSON));
         assertThrowsAssertionError(()
                 -> actualDescriptor.setSpecialisation(EditCommandUtil.VALID_INDEX, null,
-                TypicalIndexes.INDEX_FIRST_PERSON));
-        assertThrowsAssertionError(() -> actualDescriptor.setSpecialisation(null, null,
                 TypicalIndexes.INDEX_FIRST_PERSON));
     }
 
@@ -369,8 +359,6 @@ public class EditPersonDescriptorTest {
         assertThrowsAssertionError(() -> actualDescriptor.setTag(null, EditCommandUtil.VALID_TAG,
                 TypicalIndexes.INDEX_FIRST_PERSON));
         assertThrowsAssertionError(() -> actualDescriptor.setTag(EditCommandUtil.VALID_INDEX, null,
-                TypicalIndexes.INDEX_FIRST_PERSON));
-        assertThrowsAssertionError(() -> actualDescriptor.setTag(null, null,
                 TypicalIndexes.INDEX_FIRST_PERSON));
     }
 

--- a/src/test/java/networkbook/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/AddCommandParserTest.java
@@ -90,7 +90,7 @@ public class AddCommandParserTest {
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser,
                 "1" + CommandTestUtil.INVALID_EMAIL_DESC
-                        + CommandTestUtil.VALID_LINK_AMY + CommandTestUtil.VALID_PHONE_AMY,
+                        + CommandTestUtil.INVALID_LINK_DESC + CommandTestUtil.VALID_PHONE_AMY,
                 Email.MESSAGE_CONSTRAINTS);
     }
 
@@ -195,7 +195,7 @@ public class AddCommandParserTest {
         // valid followed by invalid
         Index targetIndex = TypicalIndexes.INDEX_FIRST_PERSON;
 
-        // mulltiple valid fields repeated
+        // multiple valid fields repeated
         String userInput = targetIndex.getOneBased() + CommandTestUtil.PHONE_DESC_AMY + CommandTestUtil.LINK_DESC_AMY
                 + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.TAG_DESC_FRIEND + CommandTestUtil.PHONE_DESC_AMY
                 + CommandTestUtil.LINK_DESC_AMY + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.TAG_DESC_FRIEND

--- a/src/test/java/networkbook/logic/parser/CreateCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/CreateCommandParserTest.java
@@ -251,14 +251,6 @@ public class CreateCommandParserTest {
                         + CommandTestUtil.GRADUATION_DESC_BOB + CommandTestUtil.COURSE_DESC_BOB
                         + CommandTestUtil.SPECIALISATION_DESC_BOB,
                 expectedMessage);
-
-        // all prefixes missing
-        CommandParserTestUtil.assertParseFailure(parser,
-                CommandTestUtil.VALID_NAME_BOB + CommandTestUtil.VALID_PHONE_BOB
-                        + CommandTestUtil.VALID_EMAIL_BOB + CommandTestUtil.VALID_LINK_BOB
-                        + CommandTestUtil.VALID_GRADUATION_BOB + CommandTestUtil.VALID_COURSE_BOB
-                        + CommandTestUtil.VALID_SPECIALISATION_BOB,
-                expectedMessage);
     }
 
     @Test

--- a/src/test/java/networkbook/model/person/PersonSortComparatorTest.java
+++ b/src/test/java/networkbook/model/person/PersonSortComparatorTest.java
@@ -273,7 +273,6 @@ public class PersonSortComparatorTest {
         assertTrue(PersonSortComparator.isValidSortParams(SortField.PRIORITY, SortOrder.ASCENDING));
 
         // invalid
-        assertFalse(PersonSortComparator.isValidSortParams(SortField.INVALID, SortOrder.INVALID));
         assertFalse(PersonSortComparator.isValidSortParams(SortField.NONE, SortOrder.INVALID));
         assertFalse(PersonSortComparator.isValidSortParams(SortField.INVALID, SortOrder.ASCENDING));
     }

--- a/src/test/java/networkbook/model/util/UniqueListTest.java
+++ b/src/test/java/networkbook/model/util/UniqueListTest.java
@@ -299,7 +299,7 @@ public class UniqueListTest {
     }
 
     @Test
-    public void test_falsePredicate_returnsTrue() {
+    public void test_falsePredicate_returnsFalse() {
         assertFalse(getSampleList().test(INDEX1, FALSE_PREDICATE));
         assertFalse(getSampleList().test(INDEX2, FALSE_PREDICATE));
         assertFalse(getSampleList().test(INDEX2, SAMPLE_PREDICATE));

--- a/src/test/java/networkbook/model/util/UniqueListTest.java
+++ b/src/test/java/networkbook/model/util/UniqueListTest.java
@@ -340,7 +340,6 @@ public class UniqueListTest {
     public void consumeAndComputeItem_null_throwsAssertionError() {
         assertThrowsAssertionError(() -> getSampleList().consumeAndComputeItem(INDEX1, null, SAMPLE_FUNCTION));
         assertThrowsAssertionError(() -> getSampleList().consumeAndComputeItem(INDEX1, SAMPLE_CONSUMER, null));
-        assertThrowsAssertionError(() -> getSampleList().consumeAndComputeItem(INDEX1, null, null));
     }
 
     @Test


### PR DESCRIPTION
Remove test cases with multiple invalid inputs to follow the "no more than one invalid input in a test case" heuristic.

Fixes #159 