### PR TITLE
Fix error message of invalid index of entry

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -126,6 +126,16 @@ In NetworkBook, you can manage contact information by changing the fields assign
 
 </div>
 
+<div markdown="block" class="alert alert-secondary">
+
+<span id="indices">:information_source: **Indices**</span>
+
+In NetworkBook, you often need to provide an index to specify a contact, or an entry in a multi-valued field of a contact. Indices are **integers counted from 1**.
+
+Make sure to provide indices that has a corresponding item in your book. The exact valid range is from 1 to 2147483647 inclusive. If your command contains an invalid index, it will be considered an invalid command.
+
+</div>
+
 <!-- @@author -->
 
 ### <u>Category 1 - Add contact information</u>
@@ -163,7 +173,7 @@ Format: `add [index] [field prefix] [field value] ...`
 
 Parameters:
 
-* `[index]` is the index of the contact in the list.
+* `[index]` is the index of the contact in the list, within [valid range](#indices).
 * `[field prefix]` specifies the corresponding field to add.
 * `[field value]` is the value to add to the field specified by the preceding prefix.
 
@@ -196,10 +206,10 @@ Format:
 
 Parameters:
 
-* `[index of contact]` is the index of the contact in the list.
+* `[index of contact]` is the index of the contact in the list, within [valid range](#indices).
 * `[field prefix]` specifies the field of information to edit.
 * `[field value]` is the new value to replace the original value with.
-* `[index of entry]` for a multi-valued field is the index of the element in the list representing that field.
+* `[index of entry]` for a multi-valued field is the index of the element in the list representing that field, within [valid range](#indices).
 
 For **single-valued** fields, the `/index` prefix should not be used.
 
@@ -231,7 +241,7 @@ Format: `delete [index]`
 
 Parameters:
 
-* `[index]` is the index of the contact in the list
+* `[index]` is the index of the contact in the list, within [valid range](#indices).
 
 Example usage:
 
@@ -252,9 +262,9 @@ Format:
 
 Parameters:
 
-* `[index of contact]` is the index of the contact in the list.
+* `[index of contact]` is the index of the contact in the list, within [valid range](#indices).
 * `[field prefix]` specifies the field of information to delete.
-* `[index of entry]` for a multi-valued field is the index of the element in the list representing that field.
+* `[index of entry]` for a multi-valued field is the index of the element in the list representing that field, within [valid range](#indices).
 
 For **single-valued** fields, the `/index` prefix should not be used.
 
@@ -475,8 +485,8 @@ Format: `open [index] /index [link index]`
 
 Parameters:
 
-* `[index]` is the index of the contact in the list.
-* `[link index]` is the index of the link within the contact's link list.
+* `[index]` is the index of the contact in the list, within [valid range](#indices).
+* `[link index]` is the index of the link within the contact's link list, within [valid range](#indices).
 
 <div markdown="span" class="alert alert-secondary">
 :information_source: **Note:**
@@ -501,8 +511,8 @@ Format: `email [index] /index [email index]`
 
 Parameters:
 
-* `[index]` is the index of the contact in the list.
-* `[email index]` is the index of the email address within the contact's email list.
+* `[index]` is the index of the contact in the list, within [valid range](#indices).
+* `[email index]` is the index of the email address within the contact's email list, within [valid range](#indices).
 
 <div markdown="span" class="alert alert-secondary">
 :information_source: **Note:**

--- a/src/main/java/networkbook/logic/parser/AddCommandParser.java
+++ b/src/main/java/networkbook/logic/parser/AddCommandParser.java
@@ -48,17 +48,10 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         Index index;
 
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(
-                            Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            AddCommand.MESSAGE_USAGE
-                    ),
-                    pe
-            );
-        }
+        index = ParserUtil.parseIndex(argMultimap.getPreamble(),
+                String.format(
+                        Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                        AddCommand.MESSAGE_USAGE));
 
         argMultimap.verifyNoDuplicatePrefixesFor(
                 CliSyntax.PREFIX_NAME,

--- a/src/main/java/networkbook/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/networkbook/logic/parser/DeleteCommandParser.java
@@ -52,12 +52,8 @@ public class DeleteCommandParser implements Parser<Command> {
 
         Index index;
 
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE), pe);
-        }
+        index = ParserUtil.parseIndex(argMultimap.getPreamble(),
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
 
         Prefix prefix = argMultimap.verifyAtMostOneIsPresent(
             CliSyntax.PREFIX_PHONE,
@@ -118,38 +114,44 @@ public class DeleteCommandParser implements Parser<Command> {
 
     private DeletePhoneAction generatePhoneAction(ArgumentMultimap argMultimap) throws ParseException {
         argMultimap.verifyPrefixHasEmptyValue(CliSyntax.PREFIX_PHONE);
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
         return new DeletePhoneAction(index);
     }
 
     private DeleteEmailAction generateEmailAction(ArgumentMultimap argMultimap) throws ParseException {
         argMultimap.verifyPrefixHasEmptyValue(CliSyntax.PREFIX_EMAIL);
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
         return new DeleteEmailAction(index);
     }
 
     private DeleteLinkAction generateLinkAction(ArgumentMultimap argMultimap) throws ParseException {
         argMultimap.verifyPrefixHasEmptyValue(CliSyntax.PREFIX_LINK);
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
         return new DeleteLinkAction(index);
     }
 
     private DeleteCourseAction generateCourseAction(ArgumentMultimap argMultimap) throws ParseException {
         argMultimap.verifyPrefixHasEmptyValue(CliSyntax.PREFIX_COURSE);
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
         return new DeleteCourseAction(index);
     }
 
     private DeleteSpecialisationAction generateSpecialisationAction(ArgumentMultimap argMultimap)
             throws ParseException {
         argMultimap.verifyPrefixHasEmptyValue(CliSyntax.PREFIX_SPECIALISATION);
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
         return new DeleteSpecialisationAction(index);
     }
 
     private DeleteTagAction generateTagAction(ArgumentMultimap argMultimap) throws ParseException {
         argMultimap.verifyPrefixHasEmptyValue(CliSyntax.PREFIX_TAG);
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
         return new DeleteTagAction(index);
     }
 

--- a/src/main/java/networkbook/logic/parser/EditCommandParser.java
+++ b/src/main/java/networkbook/logic/parser/EditCommandParser.java
@@ -55,17 +55,10 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         Index index;
 
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(
-                            Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                            EditCommand.MESSAGE_USAGE
-                    ),
-                    pe
-            );
-        }
+        index = ParserUtil.parseIndex(argMultimap.getPreamble(),
+                String.format(
+                        Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                        EditCommand.MESSAGE_USAGE));
 
         Prefix prefix = argMultimap.verifyExactlyOneIsPresent(
                 CliSyntax.PREFIX_NAME,
@@ -126,19 +119,22 @@ public class EditCommandParser implements Parser<EditCommand> {
 
     private static EditAction generatePhoneAction(ArgumentMultimap argMultimap) throws ParseException {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(CliSyntax.PREFIX_PHONE).get());
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         return new EditPhoneAction(index, phone);
     }
 
     private static EditAction generateEmailAction(ArgumentMultimap argMultimap) throws ParseException {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(CliSyntax.PREFIX_EMAIL).get());
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         return new EditEmailAction(index, email);
     }
 
     private static EditAction generateLinkAction(ArgumentMultimap argMultimap) throws ParseException {
         Link link = ParserUtil.parseLink(argMultimap.getValue(CliSyntax.PREFIX_LINK).get());
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         return new EditLinkAction(index, link);
     }
 
@@ -149,20 +145,23 @@ public class EditCommandParser implements Parser<EditCommand> {
 
     private static EditAction generateCourseAction(ArgumentMultimap argMultimap) throws ParseException {
         Course course = ParserUtil.parseCourseWithPrefixes(argMultimap.getValue(CliSyntax.PREFIX_COURSE).get());
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         return new EditCourseAction(index, course);
     }
 
     private static EditAction generateSpecialisationAction(ArgumentMultimap argMultimap) throws ParseException {
         Specialisation specialisation =
                 ParserUtil.parseSpecialisation(argMultimap.getValue(CliSyntax.PREFIX_SPECIALISATION).get());
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         return new EditSpecialisationAction(index, specialisation);
     }
 
     private static EditAction generateTagAction(ArgumentMultimap argMultimap) throws ParseException {
         Tag tag = ParserUtil.parseTag(argMultimap.getValue(CliSyntax.PREFIX_TAG).get());
-        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index index = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         return new EditTagAction(index, tag);
     }
 

--- a/src/main/java/networkbook/logic/parser/OpenEmailCommandParser.java
+++ b/src/main/java/networkbook/logic/parser/OpenEmailCommandParser.java
@@ -21,18 +21,13 @@ public class OpenEmailCommandParser implements Parser<OpenEmailCommand> {
 
         Index personIndex;
 
-        try {
-            personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, OpenEmailCommand.MESSAGE_USAGE),
-                    pe
-            );
-        }
+        personIndex = ParserUtil.parseIndex(argMultimap.getPreamble(),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, OpenEmailCommand.MESSAGE_USAGE));
 
         argMultimap.verifyNoDuplicatePrefixesFor(CliSyntax.PREFIX_INDEX);
 
-        Index emailIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index emailIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, OpenEmailCommand.MESSAGE_USAGE));
 
         return new OpenEmailCommand(personIndex, emailIndex);
     }

--- a/src/main/java/networkbook/logic/parser/OpenLinkCommandParser.java
+++ b/src/main/java/networkbook/logic/parser/OpenLinkCommandParser.java
@@ -21,18 +21,13 @@ public class OpenLinkCommandParser implements Parser<OpenLinkCommand> {
 
         Index personIndex;
 
-        try {
-            personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, OpenLinkCommand.MESSAGE_USAGE),
-                    pe
-            );
-        }
+        personIndex = ParserUtil.parseIndex(argMultimap.getPreamble(),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, OpenLinkCommand.MESSAGE_USAGE));
 
         argMultimap.verifyNoDuplicatePrefixesFor(CliSyntax.PREFIX_INDEX);
 
-        Index linkIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"));
+        Index linkIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_INDEX).orElse("1"),
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, OpenLinkCommand.MESSAGE_USAGE));
 
         return new OpenLinkCommand(personIndex, linkIndex);
     }

--- a/src/main/java/networkbook/logic/parser/ParserUtil.java
+++ b/src/main/java/networkbook/logic/parser/ParserUtil.java
@@ -27,7 +27,6 @@ import networkbook.model.util.UniqueList;
 public class ParserUtil {
 
     // TODO: avoid returning null for optional fields
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_PHONE_DUPLICATE = "Your list of phones contains duplicates.\n"
             + "Please ensure that you do not input the same phone more than once.";
     public static final String MESSAGE_EMAIL_DUPLICATE = "Your list of emails contains duplicates.\n"
@@ -49,10 +48,10 @@ public class ParserUtil {
      * trimmed.
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
-    public static Index parseIndex(String oneBasedIndex) throws ParseException {
+    public static Index parseIndex(String oneBasedIndex, String errorMessage) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(errorMessage);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }

--- a/src/test/java/networkbook/logic/commands/CommandTestUtil.java
+++ b/src/test/java/networkbook/logic/commands/CommandTestUtil.java
@@ -107,6 +107,15 @@ public class CommandTestUtil {
     public static final AddPersonDescriptor DESC_AMY;
     public static final AddPersonDescriptor DESC_BOB;
     public static final String VALID_INDEX_DESC = " " + CliSyntax.PREFIX_INDEX + " " + "1";
+    public static final String INVALID_INDEX_NEGATIVE = "-1";
+    public static final String INVALID_INDEX_ZERO = "0";
+    public static final String INVALID_INDEX_OVERFLOW = Long.toString(Integer.MAX_VALUE + 1);
+    public static final String INVALID_INDEX_DESC_NEGATIVE =
+            " " + CliSyntax.PREFIX_INDEX + " " + INVALID_INDEX_NEGATIVE;
+    public static final String INVALID_INDEX_DESC_ZERO =
+            " " + CliSyntax.PREFIX_INDEX + " " + INVALID_INDEX_ZERO;
+    public static final String INVALID_INDEX_DESC_OVERFLOW =
+            " " + CliSyntax.PREFIX_INDEX + " " + INVALID_INDEX_OVERFLOW;
 
     static {
         DESC_AMY = new AddPersonDescriptorBuilder()

--- a/src/test/java/networkbook/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/AddCommandParserTest.java
@@ -95,6 +95,24 @@ public class AddCommandParserTest {
     }
 
     @Test
+    public void parse_invalidIndex_failure() {
+        // negative index
+        assertParseFailure(parser, CommandTestUtil.INVALID_INDEX_DESC_NEGATIVE
+                        + CommandTestUtil.VALID_COURSE_DESC + CommandTestUtil.VALID_COURSE_AMY,
+                        MESSAGE_INVALID_FORMAT);
+
+        // zero
+        assertParseFailure(parser, CommandTestUtil.INVALID_INDEX_DESC_ZERO
+                        + CommandTestUtil.VALID_TAG_DESC + CommandTestUtil.VALID_TAG_FRIEND,
+                MESSAGE_INVALID_FORMAT);
+
+        // integer overflow
+        assertParseFailure(parser, CommandTestUtil.INVALID_INDEX_DESC_OVERFLOW
+                        + CommandTestUtil.VALID_TAG_DESC + CommandTestUtil.VALID_TAG_FRIEND,
+                MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
     public void parse_nameSpecified_failure() {
         Index index = TypicalIndexes.INDEX_FIRST_PERSON;
         String userInput = index.getOneBased() + CommandTestUtil.VALID_NAME_DESC;

--- a/src/test/java/networkbook/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/AddCommandParserTest.java
@@ -126,7 +126,8 @@ public class AddCommandParserTest {
                 + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.LINK_DESC_AMY
                 + CommandTestUtil.GRADUATION_DESC_AMY + CommandTestUtil.COURSE_DESC_AMY
                 + CommandTestUtil.SPECIALISATION_DESC_AMY
-                + CommandTestUtil.TAG_DESC_FRIEND;
+                + CommandTestUtil.TAG_DESC_FRIEND
+                + CommandTestUtil.PRIORITY_DESC_AMY;
 
         AddPersonDescriptor descriptor = new AddPersonDescriptorBuilder()
                 .withPhone(CommandTestUtil.VALID_PHONE_BOB)
@@ -136,6 +137,7 @@ public class AddCommandParserTest {
                 .withCourse(CommandTestUtil.VALID_COURSE_AMY)
                 .withSpecialisation(CommandTestUtil.VALID_SPECIALISATION_AMY)
                 .withTags(CommandTestUtil.VALID_TAG_HUSBAND, CommandTestUtil.VALID_TAG_FRIEND)
+                .withPriority(CommandTestUtil.VALID_PRIORITY_AMY)
                 .build();
         AddCommand expectedCommand = new AddCommand(targetIndex, descriptor);
 

--- a/src/test/java/networkbook/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/DeleteCommandParserTest.java
@@ -1,9 +1,12 @@
 package networkbook.logic.parser;
 
+import static networkbook.logic.parser.CommandParserTestUtil.assertParseFailure;
+
 import org.junit.jupiter.api.Test;
 
 import networkbook.commons.core.index.Index;
 import networkbook.logic.Messages;
+import networkbook.logic.commands.CommandTestUtil;
 import networkbook.logic.commands.delete.DeleteCourseAction;
 import networkbook.logic.commands.delete.DeleteEmailAction;
 import networkbook.logic.commands.delete.DeleteFieldCommand;
@@ -16,12 +19,15 @@ import networkbook.logic.commands.delete.DeleteSpecialisationAction;
 import networkbook.logic.commands.delete.DeleteTagAction;
 import networkbook.testutil.TypicalIndexes;
 
+
 /**
  * Test class that contains unit test cases for {@code DeleteCommandParser}.
  */
 public class DeleteCommandParserTest {
 
     private static final DeleteCommandParser parser = new DeleteCommandParser();
+    private static final String MESSAGE_INVALID_COMMAND = String.format(
+            Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE);
 
     private static final String NAME = CliSyntax.PREFIX_NAME.getPrefix();
     private static final String PHONE = CliSyntax.PREFIX_PHONE.getPrefix();
@@ -69,148 +75,174 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidIndex_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser, "a",
+        assertParseFailure(parser, "a",
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
     }
 
     @Test
+    public void parse_invalidIndexOfContact_failure() {
+        assertParseFailure(parser,
+                CommandTestUtil.INVALID_INDEX_NEGATIVE + WHITESPACE + PRIORITY,
+                MESSAGE_INVALID_COMMAND);
+        assertParseFailure(parser,
+                CommandTestUtil.INVALID_INDEX_ZERO + WHITESPACE + GRADUATION,
+                MESSAGE_INVALID_COMMAND);
+        assertParseFailure(parser,
+                CommandTestUtil.INVALID_INDEX_OVERFLOW,
+                MESSAGE_INVALID_COMMAND);
+    }
+
+    @Test
+    public void parse_invalidIndexOfEntry_failure() {
+        assertParseFailure(parser,
+                "1" + WHITESPACE + COURSE + CommandTestUtil.INVALID_INDEX_DESC_NEGATIVE,
+                MESSAGE_INVALID_COMMAND);
+        assertParseFailure(parser,
+                "1" + WHITESPACE + SPECIALISATION + CommandTestUtil.INVALID_INDEX_DESC_ZERO,
+                MESSAGE_INVALID_COMMAND);
+        assertParseFailure(parser,
+                "1" + WHITESPACE + TAG + CommandTestUtil.INVALID_INDEX_DESC_OVERFLOW,
+                MESSAGE_INVALID_COMMAND);
+    }
+
+    @Test
     public void parse_noPersonIndex_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser, WHITESPACE,
+        assertParseFailure(parser, WHITESPACE,
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(NAME),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(INDEX, ONE),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(INDEX),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(PRIORITY),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_deleteName_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, NAME),
                 DeleteCommandParser.MESSAGE_DELETE_NAME);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, PHONE, NAME, RANDOM),
                 DeleteCommandParser.MESSAGE_DELETE_NAME);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, NAME, INDEX, ONE),
                 DeleteCommandParser.MESSAGE_DELETE_NAME);
     }
 
     @Test
     public void parse_deleteInvalidPrefix_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, INVALID_PREFIX),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, INVALID_PREFIX, INDEX, ONE),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, INVALID_PREFIX, GRADUATION),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, INVALID_PREFIX, TAG, INDEX, ONE),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, INDEX),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, INDEX, ONE),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, INDEX, ONE, INDEX, TWO),
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_deleteMultiplePrefixes_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, GRADUATION, PRIORITY),
                 Messages.MESSAGE_EXACTLY_ONE_FIELD);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, GRADUATION, TAG),
                 Messages.MESSAGE_EXACTLY_ONE_FIELD);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, TAG, GRADUATION, PRIORITY),
                 Messages.MESSAGE_EXACTLY_ONE_FIELD);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, GRADUATION, TAG, INDEX, ONE),
                 Messages.MESSAGE_EXACTLY_ONE_FIELD);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, GRADUATION, PRIORITY, INDEX, ONE),
                 Messages.MESSAGE_EXACTLY_ONE_FIELD);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, GRADUATION, INDEX, ONE, PRIORITY),
                 Messages.MESSAGE_EXACTLY_ONE_FIELD);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, GRADUATION, RANDOM, PRIORITY),
                 Messages.MESSAGE_EXACTLY_ONE_FIELD);
     }
 
     @Test
     public void parse_deleteSamePrefixMultipleTimes_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, PRIORITY, PRIORITY),
                 Messages.MESSAGE_DUPLICATE_PREFIX);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, EMAIL, INDEX, ONE, EMAIL, INDEX, ONE),
                 Messages.MESSAGE_DUPLICATE_PREFIX);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, LINK, GRADUATION, LINK),
                 Messages.MESSAGE_DUPLICATE_PREFIX);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, COURSE, RANDOM, COURSE, INDEX, PRIORITY),
                 Messages.MESSAGE_DUPLICATE_PREFIX);
     }
 
     @Test
     public void parse_deleteMultiValuedFieldInvalidIndex_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, SPECIALISATION, INDEX, ONE, INDEX, TWO),
                 Messages.MESSAGE_DUPLICATE_SINGLE_VALUED_FIELDS + CliSyntax.PREFIX_INDEX);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, LINK, INDEX, ONE, INDEX, ONE),
                 Messages.MESSAGE_DUPLICATE_SINGLE_VALUED_FIELDS + CliSyntax.PREFIX_INDEX);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, COURSE, INDEX, INDEX),
                 Messages.MESSAGE_DUPLICATE_SINGLE_VALUED_FIELDS + CliSyntax.PREFIX_INDEX);
     }
 
     @Test
     public void parse_deleteSingleValuedFieldUsingIndex_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, PRIORITY, INDEX, ONE),
                 Messages.MESSAGE_INDEX_CANNOT_BE_PRESENT);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, PRIORITY, INDEX, ONE, INDEX, TWO),
                 Messages.MESSAGE_INDEX_CANNOT_BE_PRESENT);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, GRADUATION, INDEX),
                 Messages.MESSAGE_INDEX_CANNOT_BE_PRESENT);
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, GRADUATION, INDEX, RANDOM),
                 Messages.MESSAGE_INDEX_CANNOT_BE_PRESENT);
     }
 
     @Test
     public void parse_deleteWithRedundantValue_throwsParseException() {
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, PRIORITY, RANDOM),
                 String.format(Messages.MESSAGE_VALUE_CANNOT_BE_PRESENT, PRIORITY));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, GRADUATION, RANDOM),
                 String.format(Messages.MESSAGE_VALUE_CANNOT_BE_PRESENT, GRADUATION));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, TAG, RANDOM, INDEX, ONE),
                 String.format(Messages.MESSAGE_VALUE_CANNOT_BE_PRESENT, TAG));
-        CommandParserTestUtil.assertParseFailure(parser,
+        assertParseFailure(parser,
                 generateUserInput(ONE, INDEX, ONE, LINK, RANDOM),
                 String.format(Messages.MESSAGE_VALUE_CANNOT_BE_PRESENT, LINK));
     }

--- a/src/test/java/networkbook/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/EditCommandParserTest.java
@@ -79,6 +79,32 @@ public class EditCommandParserTest {
     }
 
     @Test
+    public void parse_invalidIndexOfContact_failure() {
+        assertParseFailure(PARSER,
+                CommandTestUtil.INVALID_INDEX_NEGATIVE + CommandTestUtil.VALID_PHONE_DESC,
+                USAGE_MESSAGE);
+        assertParseFailure(PARSER,
+                CommandTestUtil.INVALID_INDEX_ZERO + CommandTestUtil.VALID_PHONE_DESC,
+                USAGE_MESSAGE);
+        assertParseFailure(PARSER,
+                CommandTestUtil.INVALID_INDEX_OVERFLOW + CommandTestUtil.VALID_PHONE_DESC,
+                USAGE_MESSAGE);
+    }
+
+    @Test
+    public void parse_invalidIndexOfEntry_failure() {
+        assertParseFailure(PARSER,
+                "1" + CommandTestUtil.VALID_PHONE_DESC + CommandTestUtil.INVALID_INDEX_DESC_NEGATIVE,
+                USAGE_MESSAGE);
+        assertParseFailure(PARSER,
+                "1" + CommandTestUtil.VALID_EMAIL_DESC + CommandTestUtil.INVALID_INDEX_DESC_ZERO,
+                USAGE_MESSAGE);
+        assertParseFailure(PARSER,
+                "1" + CommandTestUtil.VALID_LINK_DESC + CommandTestUtil.INVALID_INDEX_DESC_OVERFLOW,
+                USAGE_MESSAGE);
+    }
+
+    @Test
     public void parse_listItemFieldWithoutIndexSpecified_success() {
         EditCommand expectedEditPhoneCommand = new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON,
                 new EditPhoneAction(Index.fromOneBased(1), new Phone("123456")));

--- a/src/test/java/networkbook/logic/parser/OpenEmailCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/OpenEmailCommandParserTest.java
@@ -13,6 +13,8 @@ import networkbook.testutil.TypicalIndexes;
 
 public class OpenEmailCommandParserTest {
     private static final OpenEmailCommandParser PARSER = new OpenEmailCommandParser();
+    private static final String MESSAGE_INVALID_FORMAT = String.format(
+            Messages.MESSAGE_INVALID_COMMAND_FORMAT, OpenEmailCommand.MESSAGE_USAGE);
 
     @Test
     public void parse_missingPreamble_failure() {
@@ -30,6 +32,38 @@ public class OpenEmailCommandParserTest {
         assertParseFailure(PARSER, "0", expectedMessage);
         assertParseFailure(PARSER, "1 what", expectedMessage);
         assertParseFailure(PARSER, "lol", expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidIndexOfContact_failure() {
+        // negative index
+        assertParseFailure(PARSER, CommandTestUtil.INVALID_INDEX_DESC_NEGATIVE
+                        + CommandTestUtil.VALID_INDEX_DESC,
+                MESSAGE_INVALID_FORMAT);
+
+        // zero
+        assertParseFailure(PARSER, CommandTestUtil.INVALID_INDEX_ZERO
+                        + CommandTestUtil.VALID_INDEX_DESC,
+                MESSAGE_INVALID_FORMAT);
+
+        // integer overflow
+        assertParseFailure(PARSER, CommandTestUtil.INVALID_INDEX_OVERFLOW,
+                MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidIndexOfEmail_failure() {
+        // negative index
+        assertParseFailure(PARSER, "1" + CommandTestUtil.INVALID_INDEX_DESC_NEGATIVE,
+                MESSAGE_INVALID_FORMAT);
+
+        // zero
+        assertParseFailure(PARSER, "1" + CommandTestUtil.INVALID_INDEX_DESC_ZERO,
+                MESSAGE_INVALID_FORMAT);
+
+        // integer overflow
+        assertParseFailure(PARSER, "1" + CommandTestUtil.INVALID_INDEX_DESC_OVERFLOW,
+                MESSAGE_INVALID_FORMAT);
     }
 
     @Test

--- a/src/test/java/networkbook/logic/parser/OpenLinkCommandParserTest.java
+++ b/src/test/java/networkbook/logic/parser/OpenLinkCommandParserTest.java
@@ -14,6 +14,8 @@ import networkbook.testutil.TypicalIndexes;
 
 public class OpenLinkCommandParserTest {
     private static final OpenLinkCommandParser PARSER = new OpenLinkCommandParser();
+    private static final String MESSAGE_INVALID_FORMAT = String.format(
+            Messages.MESSAGE_INVALID_COMMAND_FORMAT, OpenLinkCommand.MESSAGE_USAGE);
 
     @Test
     public void parse_missingPreamble_failure() {
@@ -29,6 +31,38 @@ public class OpenLinkCommandParserTest {
         assertParseFailure(PARSER, "0", expectedMessage);
         assertParseFailure(PARSER, "1 what", expectedMessage);
         assertParseFailure(PARSER, "lol", expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidIndexOfContact_failure() {
+        // negative index
+        assertParseFailure(PARSER, CommandTestUtil.INVALID_INDEX_DESC_NEGATIVE
+                        + CommandTestUtil.VALID_INDEX_DESC,
+                MESSAGE_INVALID_FORMAT);
+
+        // zero
+        assertParseFailure(PARSER, CommandTestUtil.INVALID_INDEX_DESC_ZERO
+                        + CommandTestUtil.VALID_INDEX_DESC,
+                MESSAGE_INVALID_FORMAT);
+
+        // integer overflow
+        assertParseFailure(PARSER, CommandTestUtil.INVALID_INDEX_OVERFLOW,
+                MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidIndexOfLink_failure() {
+        // negative index
+        assertParseFailure(PARSER, "1" + CommandTestUtil.INVALID_INDEX_DESC_NEGATIVE,
+                MESSAGE_INVALID_FORMAT);
+
+        // zero
+        assertParseFailure(PARSER, "1" + CommandTestUtil.INVALID_INDEX_DESC_ZERO,
+                MESSAGE_INVALID_FORMAT);
+
+        // integer overflow
+        assertParseFailure(PARSER, "1" + CommandTestUtil.INVALID_INDEX_OVERFLOW,
+                MESSAGE_INVALID_FORMAT);
     }
 
     @Test

--- a/src/test/java/networkbook/logic/parser/ParserUtilTest.java
+++ b/src/test/java/networkbook/logic/parser/ParserUtilTest.java
@@ -9,6 +9,9 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import networkbook.logic.Messages;
+import networkbook.logic.commands.delete.DeletePersonCommand;
+import networkbook.logic.commands.edit.EditCommand;
 import networkbook.logic.parser.exceptions.ParseException;
 import networkbook.model.person.Course;
 import networkbook.model.person.Email;
@@ -54,25 +57,34 @@ public class ParserUtilTest {
 
     private static final String WHITESPACE = " \t\r\n";
 
+    private static final String EDIT_INVALID_COMMAND_MESSAGE =
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+
+    private static final String DELETE_INVALID_COMMAND_MESSAGE =
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE);
+
 
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a",
+                EDIT_INVALID_COMMAND_MESSAGE));
     }
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, ParserUtil.MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        assertThrows(ParseException.class, DELETE_INVALID_COMMAND_MESSAGE, ()
+            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1), DELETE_INVALID_COMMAND_MESSAGE));
     }
 
     @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
-        assertEquals(TypicalIndexes.INDEX_FIRST_PERSON, ParserUtil.parseIndex("1"));
+        assertEquals(TypicalIndexes.INDEX_FIRST_PERSON, ParserUtil.parseIndex("1",
+                EDIT_INVALID_COMMAND_MESSAGE));
 
         // Leading and trailing whitespaces
-        assertEquals(TypicalIndexes.INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+        assertEquals(TypicalIndexes.INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  ",
+                DELETE_INVALID_COMMAND_MESSAGE));
     }
 
     @Test


### PR DESCRIPTION
Before, when a number greater than `Integer.MAX_VALUE` is provided as index of entry for a multi-valued field, the error message was "Index is not a non-zero unsigned integer". The error message was wrong because the index could still be a non-zero unsigned integer.

Now, the error message will be consistent with index of contact, which will be "invalid command" followed by command usage.


Also updated UG to specify valid range of `index`. 
❗I feel it's too repetitive to repeat the valid range under every `index` parameter. Thus, I extracted the explanation at the start of "features" section and made hyperlinks to refer to that tip box. Please review and offer suggestions if u have a better idea how to organise it.

Closes #211.