### PR TITLE
Fix contact duplicate checking issue

### DIFF
--- a/src/main/java/networkbook/model/person/Name.java
+++ b/src/main/java/networkbook/model/person/Name.java
@@ -56,7 +56,7 @@ public class Name implements Comparable<Name> {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override

--- a/src/test/java/networkbook/model/person/NameTest.java
+++ b/src/test/java/networkbook/model/person/NameTest.java
@@ -45,6 +45,9 @@ public class NameTest {
         // same values -> returns true
         assertTrue(name.equals(new Name("Valid Name")));
 
+        // same values ignoring case -> returns true
+        assertTrue(name.equals(new Name("valid name")));
+
         // same object -> returns true
         assertTrue(name.equals(name));
 

--- a/src/test/java/networkbook/model/person/PersonTest.java
+++ b/src/test/java/networkbook/model/person/PersonTest.java
@@ -48,9 +48,9 @@ public class PersonTest {
         editedAmy = new PersonBuilder(TypicalPersons.ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(TypicalPersons.ALICE.isSame(editedAmy));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(TypicalPersons.BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(TypicalPersons.BOB.isSame(editedBob));
+        assertTrue(TypicalPersons.BOB.isSame(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";


### PR DESCRIPTION
Previously, contacts with same name ignoring case are not detected as duplicate if the two names have different cases.
Now, duplicate checking ignores cases.